### PR TITLE
Feat/add button component 10

### DIFF
--- a/PawCut/PawCut/Sources/DesignSystem/Component/Button/PawChoiceButton.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Button/PawChoiceButton.swift
@@ -1,0 +1,63 @@
+//
+//  PawChoiceButton.swift
+//  PawCut
+//
+//  Created by Luminouxx on 7/15/25.
+//
+
+import SwiftUI
+
+struct PawChoiceButton: View {
+    private let title: String
+    private let isEnabled: Bool
+    private let action: () -> Void
+    private let textPadding: CGFloat = 16
+    private let horizontalPadding: CGFloat
+    private let verticalPadding: CGFloat
+    
+    init(
+        _ title: String,
+        isEnabled: Bool = true,
+        horizontalPadding: CGFloat = 20,
+        verticalPadding: CGFloat = 20,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.isEnabled = isEnabled
+        self.action = action
+        self.horizontalPadding = horizontalPadding
+        self.verticalPadding = verticalPadding
+    }
+    
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .pretendardFont(size: ._16, weight: .semibold)
+                .padding(.top, textPadding)
+                .padding(.bottom, textPadding)
+                .foregroundColor(isEnabled ? .pointPurple01 : .grayScale01)
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(isEnabled ? .pointPurple02 : .grayScale05)
+                        .stroke(isEnabled ? .pointPurple01 : .grayScale05, lineWidth: 1)
+                )
+        }
+        .padding(.horizontal, horizontalPadding)
+        .padding(.vertical, verticalPadding)
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+#Preview {
+    HStack(spacing: 12) {
+        PawChoiceButton("강아지", isEnabled: true, horizontalPadding: 0) {
+            
+        }
+        
+        PawChoiceButton("고양이", isEnabled: false, horizontalPadding: 0) {
+            
+        }
+    }
+    .padding(20)
+}

--- a/PawCut/PawCut/Sources/DesignSystem/Component/Button/PawPrimaryButton.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Button/PawPrimaryButton.swift
@@ -9,20 +9,24 @@ import SwiftUI
 
 struct PawPrimaryButton: View {
     
-    @State private var isEnabled: Bool = true
-    
     private let title: String
+    private let isEnabled: Bool
     private let action: () -> Void
+    private let textPadding: CGFloat
     private let horizontalPadding: CGFloat
     private let verticalPadding: CGFloat
     
     init(
         _ title: String,
+        isEnabled: Bool = true,
+        textPadding: CGFloat = 20,
         horizontalPadding: CGFloat = 20,
         verticalPadding: CGFloat = 20,
         action: @escaping () -> Void
     ) {
         self.title = title
+        self.isEnabled = isEnabled
+        self.textPadding = textPadding
         self.action = action
         self.horizontalPadding = horizontalPadding
         self.verticalPadding = verticalPadding
@@ -32,7 +36,8 @@ struct PawPrimaryButton: View {
         Button(action: action) {
             Text(title)
                 .pretendardFont(size: ._16, weight: .semibold)
-                .padding(EdgeInsets(top: 20, leading: 0, bottom: 20, trailing: 0))
+                .padding(.top, textPadding)
+                .padding(.bottom, textPadding)
                 .foregroundColor(.grayScale06)
                 .frame(maxWidth: .infinity)
                 .background(

--- a/PawCut/PawCut/Sources/DesignSystem/Component/Button/PawPrimaryButton.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Button/PawPrimaryButton.swift
@@ -11,28 +11,43 @@ struct PawPrimaryButton: View {
     
     @State private var isEnabled: Bool = true
     
-    let title: String
-    let action: () -> Void
+    private let title: String
+    private let action: () -> Void
+    private let horizontalPadding: CGFloat
+    private let verticalPadding: CGFloat
+    
+    init(
+        _ title: String,
+        horizontalPadding: CGFloat = 20,
+        verticalPadding: CGFloat = 20,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.action = action
+        self.horizontalPadding = horizontalPadding
+        self.verticalPadding = verticalPadding
+    }
     
     var body: some View {
         Button(action: action) {
             Text(title)
                 .pretendardFont(size: ._16, weight: .semibold)
                 .padding(EdgeInsets(top: 20, leading: 0, bottom: 20, trailing: 0))
-                .foregroundColor(Color(.grayScale06))
+                .foregroundColor(.grayScale06)
                 .frame(maxWidth: .infinity)
                 .background(
                     RoundedRectangle(cornerRadius: 12)
                         .fill(isEnabled ? .pointPurple01 : .grayScale03)
                 )
         }
-        .padding(20)
+        .padding(.horizontal, horizontalPadding)
+        .padding(.vertical, verticalPadding)
         .buttonStyle(PlainButtonStyle())
     }
 }
 
 #Preview {
-    PawPrimaryButton(title: "안녕하세요") {
-        print("hello")
+    PawPrimaryButton("PrimaryButton") {
+        
     }
 }

--- a/PawCut/PawCut/Sources/DesignSystem/Component/Button/PawPrimaryButton.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Button/PawPrimaryButton.swift
@@ -1,0 +1,38 @@
+//
+//  PawPrimaryButton.swift
+//  PawCut
+//
+//  Created by Luminouxx on 7/14/25.
+//
+
+import SwiftUI
+
+struct PawPrimaryButton: View {
+    
+    @State private var isEnabled: Bool = true
+    
+    let title: String
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .pretendardFont(size: ._16, weight: .semibold)
+                .padding(EdgeInsets(top: 20, leading: 0, bottom: 20, trailing: 0))
+                .foregroundColor(Color(.grayScale06))
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(isEnabled ? .pointPurple01 : .grayScale03)
+                )
+        }
+        .padding(20)
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+#Preview {
+    PawPrimaryButton(title: "안녕하세요") {
+        print("hello")
+    }
+}

--- a/PawCut/PawCut/Sources/DesignSystem/Component/Button/PawSecondaryButton.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Button/PawSecondaryButton.swift
@@ -1,0 +1,55 @@
+//
+//  PawSecondaryButton.swift
+//  PawCut
+//
+//  Created by Luminouxx on 7/15/25.
+//
+
+import SwiftUI
+
+struct PawSecondaryButton: View {
+    
+    private let title: String
+    private let action: () -> Void
+    private let textPadding: CGFloat
+    private let horizontalPadding: CGFloat
+    private let verticalPadding: CGFloat
+    
+    init(
+        _ title: String,
+        textPadding: CGFloat = 20,
+        horizontalPadding: CGFloat = 20,
+        verticalPadding: CGFloat = 20,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.action = action
+        self.textPadding = textPadding
+        self.horizontalPadding = horizontalPadding
+        self.verticalPadding = verticalPadding
+    }
+    
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .pretendardFont(size: ._16, weight: .semibold)
+                .padding(.top, textPadding)
+                .padding(.bottom, textPadding)
+                .foregroundColor(.grayScale03)
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(.grayScale05)
+                )
+        }
+        .padding(.horizontal, horizontalPadding)
+        .padding(.vertical, verticalPadding)
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+#Preview {
+    PawSecondaryButton("SecondaryButton") {
+        
+    }
+}


### PR DESCRIPTION
## 변경 사항 (Changes)
+ 185139e : feat: PawPrimaryButton 컴포넌트 추가
+ a3d1426 : feat: PawPrimaryButton 상하좌우 패딩 조절할 수 있도록 변경
+ a0ae0b9 : feat: PawSecondaryButton 컴포넌트 추가
+ 3b816a9 : feat: PawPrimaryButton에 textPadding 파라미터 추가
+ ae82b8f : feat: PawChoiceButton 컴포넌트 추가

## 변경 이유 (Reason for Changes)
PAWCUT 프로젝트에서 재사용할 버튼 컴포넌트를 제작했습니다.

```swift
struct PawChoiceButton: View {
    private let title: String
    private let isEnabled: Bool
    private let action: () -> Void
    private let textPadding: CGFloat = 16
    private let horizontalPadding: CGFloat
    private let verticalPadding: CGFloat
    
    init(
        _ title: String,
        isEnabled: Bool = true,
        horizontalPadding: CGFloat = 20,
        verticalPadding: CGFloat = 20,
        action: @escaping () -> Void
    ) {
        self.title = title
        self.isEnabled = isEnabled
        self.action = action
        self.horizontalPadding = horizontalPadding
        self.verticalPadding = verticalPadding
    }
```
### 파라미터 설명
+ title : 버튼의 제목입니다.
+ isEnabled : 버튼의 활성 비활성 상태가 필요할 경우, 사용할 파라미터 입니다. 초기값으로 true를 설정합니다.
+ textPadding : 텍스트의 상하 패딩 (PawChoiceButton에서만 사용됩니다.)
+ horizontalPadding : 버튼의 좌우패딩, 초기값을 20으로 설정합니다.
+ verticalPadding : 버튼의 상하패딩, 초기값을 20으로 설정합니다.
+ action : 버튼을 눌렀을 때, 실행되는 클로저입니다.


## 관련 이슈 (Related Issue)
+ closes #10 

## 테스트 방법 (How to Test)

각 버튼 컴포넌트의 Preview를 확인하세요.
```swift
#Preview {
    PawPrimaryButton("PrimaryButton") {
        // 여기에 로직 추가
    }
}
```

## 추가 정보 (Additional Information)
사실 조금 더 추상화 레벨을 높이고 싶었습니다.
하지만, 해당 작업은 추후에 다른 분이 진행하면 좋을 것 같습니다.
