### PR TITLE
[Feature] TextField Component 제작 #14

### DIFF
--- a/PawCut/PawCut/Sources/DesignSystem/Component/TextField/PawTextField.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/TextField/PawTextField.swift
@@ -1,0 +1,83 @@
+//
+//  PawTextField.swift
+//  PawCut
+//
+//  Created by Luminouxx on 7/15/25.
+//
+
+import SwiftUI
+
+struct PawTextField: View {
+    
+    @Binding private var text: String
+    @Binding private var isError: Bool
+    @FocusState private var isFocused: Bool
+    
+    private let placeholder: String
+    private let errorMessage: String?
+    
+    init(
+        _ placeholder: String,
+        text: Binding<String>,
+        isError: Binding<Bool>,
+        errorMessage: String? = nil
+    ) {
+        self.placeholder = placeholder
+        self._text = text
+        self._isError = isError
+        self.errorMessage = errorMessage
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                TextField(placeholder, text: $text)
+                    .pretendardFont(size: ._14, weight: .semibold)
+                    .focused($isFocused)
+                    .foregroundColor(isFocused ? .grayScale01 : .grayScale04)
+                
+                if isFocused && !text.isEmpty {
+                    Button {
+                        text = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.grayScale04)
+                    }
+                }
+            }
+            .padding(EdgeInsets(top: 20, leading: 16, bottom: 20, trailing: 16))
+            .background(.grayScale05)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isError ? .pointRed02 : .grayScale05, lineWidth: 1)
+            )
+            
+            if isError, let errorMessage = errorMessage {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .foregroundColor(.pointRed01)
+                        .font(.system(size: 12))
+                    
+                    Text(errorMessage)
+                        .pretendardFont(size: ._12, weight: .medium)
+                        .foregroundColor(.pointRed01)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        PawTextField("이름을 입력해 주세요", text: .constant(""), isError: .constant(false))
+        
+        PawTextField(
+            "이름을 입력해 주세요",
+            text: .constant("잘못된 입력"),
+            isError: .constant(true),
+            errorMessage: "공백없이 1자 이상 5자 이하로 입력해주세요."
+        )
+    }
+    .padding(20)
+}


### PR DESCRIPTION
## 변경 사항 (Changes)
+ f7cbeee : feat: PawTextField 컴포넌트 추가

## 변경 이유 (Reason for Changes)
PAWCUT 프로젝트에서 재사용할 텍스트필드 컴포넌트를 제작했습니다.

```swift
struct PawTextField: View {
    
    @Binding private var text: String  // 바인딩 되는 텍스트
    @Binding private var isError: Bool // 유효성 검사 Bool 변수 (유효성 검사 안하는 경우는 없다고 합니다.)
    @FocusState private var isFocused: Bool // 텍스트 필드 입력 감시 Bool 변수
    
    private let placeholder: String // placeHolder 텍스트
    private let errorMessage: String? // 에러메시지
    
```


## 관련 이슈 (Related Issue)
+ closes #14 

## 테스트 방법 (How to Test)

> Simulator 실행 화면을 첨부했습니다.

https://github.com/user-attachments/assets/1242c795-df0e-4dbe-aae7-39cdadc34f38


## 추가 정보 (Additional Information)
> 없습니다.
