### PR TITLE
[Feature] Onboarding Flow Navigation 연결

### DIFF
--- a/PawCut/PawCut.xcodeproj/project.pbxproj
+++ b/PawCut/PawCut.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
-				Sources/ViewModels/.gitkeep,
 			);
 			target = CC17719D2E1D2ED600F1B71F /* PawCut */;
 		};

--- a/PawCut/PawCut/Sources/ViewModels/Onboarding/FirstOnboardingViewModel.swift
+++ b/PawCut/PawCut/Sources/ViewModels/Onboarding/FirstOnboardingViewModel.swift
@@ -1,0 +1,20 @@
+//
+//  OnboardingViewModel.swift
+//  PawCut
+//
+//  Created by Luminouxx on 8/11/25.
+//
+
+import Foundation
+
+@MainActor
+class FirstOnboardingViewModel: ObservableObject {
+    
+    private let navigationManager = NavigationManager.shared
+    
+    let currentPage: Int = 0
+    
+    func tapNextButton() {
+        navigationManager.navigate(to: .onboarding(.secondOnboarding))
+    }
+}

--- a/PawCut/PawCut/Sources/ViewModels/Onboarding/SecondOnboardingViewModel.swift
+++ b/PawCut/PawCut/Sources/ViewModels/Onboarding/SecondOnboardingViewModel.swift
@@ -1,0 +1,20 @@
+//
+//  SecondOnboardingViewModel.swift
+//  PawCut
+//
+//  Created by Luminouxx on 8/11/25.
+//
+
+import Foundation
+
+@MainActor
+class SecondOnboardingViewModel: ObservableObject {
+    
+    private let navigationManager = NavigationManager.shared
+    
+    let currentPage: Int = 1
+    
+    func tapNextButton() {
+        navigationManager.navigate(to: .onboarding(.thirdOnboarding))
+    }
+}

--- a/PawCut/PawCut/Sources/ViewModels/Onboarding/ThirdOnboardingViewModel.swift
+++ b/PawCut/PawCut/Sources/ViewModels/Onboarding/ThirdOnboardingViewModel.swift
@@ -1,0 +1,21 @@
+//
+//  ThirdOnboardingViewModel.swift
+//  PawCut
+//
+//  Created by Luminouxx on 8/11/25.
+//
+
+import Foundation
+
+@MainActor
+class ThirdOnboardingViewModel: ObservableObject {
+    
+    private let navigationManager = NavigationManager.shared
+    
+    let currentPage: Int = 2
+    
+    func tapNextButton() {
+        // TODO: 아직 미정되었기 때문에, 추후 수정
+        navigationManager.navigate(to: .main(.home))
+    }
+}

--- a/PawCut/PawCut/Sources/Views/Onboarding/FirstOnboardingView.swift
+++ b/PawCut/PawCut/Sources/Views/Onboarding/FirstOnboardingView.swift
@@ -8,9 +8,10 @@
 import SwiftUI
 
 struct FirstOnboardingView: View {
-    @State private var currentPage: Int = 0
+    
+    @StateObject private var viewModel = FirstOnboardingViewModel()
+
     var body: some View {
-        Spacer()
         VStack{
             Text("귀가 쫑긋! \n그 찰나를 담아보세요")
                 .font(.pretendard(size: ._24 ,weight: .semibold))
@@ -24,16 +25,20 @@ struct FirstOnboardingView: View {
                 .foregroundColor(.grayScale03)
                 .padding(.bottom,102)
             
+            
             ImageComponent(
                 imageName: "onboarding_1",
                 size: CGSize(width: 220, height: 251)
             )
             .padding(.bottom,96)
-            PageControl(numberOfPages: 3, currentPage:currentPage)
+            
+            PageControl(numberOfPages: 3, currentPage: viewModel.currentPage)
+            
             PawPrimaryButton("다음"){
-                print("다음")
+                viewModel.tapNextButton()
             }
         }
+        .navigationBarBackButtonHidden()
     }
 }
 

--- a/PawCut/PawCut/Sources/Views/Onboarding/SecondOnboardingView.swift
+++ b/PawCut/PawCut/Sources/Views/Onboarding/SecondOnboardingView.swift
@@ -8,9 +8,10 @@
 import SwiftUI
 
 struct SecondOnboardingView: View {
-    @State private var currentPage: Int = 1
+    
+    @StateObject private var viewModel = SecondOnboardingViewModel()
+    
     var body: some View {
-        Spacer()
         VStack{
             Text("특별한 날에는,\n포우-컷으로 남겨보세요")
                 .font(.pretendard(size: ._24 ,weight: .semibold))
@@ -29,11 +30,14 @@ struct SecondOnboardingView: View {
                 size: CGSize(width: 180, height: 258)
             )
             .padding(.bottom,94)
-            PageControl(numberOfPages: 3, currentPage:currentPage)
+            
+            PageControl(numberOfPages: 3, currentPage: viewModel.currentPage)
+            
             PawPrimaryButton("다음"){
-                print("다음")
+                viewModel.tapNextButton()
             }
         }
+        .navigationBarBackButtonHidden()
     }
 }
 

--- a/PawCut/PawCut/Sources/Views/Onboarding/ThirdOnboardingView.swift
+++ b/PawCut/PawCut/Sources/Views/Onboarding/ThirdOnboardingView.swift
@@ -8,9 +8,10 @@
 import SwiftUI
 
 struct ThirdOnboardingView: View {
-    @State private var currentPage: Int = 2
+    
+    @StateObject private var viewModel = ThirdOnboardingViewModel()
+    
     var body: some View {
-        Spacer()
         VStack{
             Text("사진은 언제나\n다시 꺼내볼 수 있어요")
                 .font(.pretendard(size: ._24 ,weight: .semibold))
@@ -29,11 +30,14 @@ struct ThirdOnboardingView: View {
                 size: CGSize(width: 200, height: 265)
             )
             .padding(.bottom,93)
-            PageControl(numberOfPages: 3, currentPage:currentPage)
+            
+            PageControl(numberOfPages: 3, currentPage: viewModel.currentPage)
+            
             PawPrimaryButton("다음"){
-                print("다음")
+                viewModel.tapNextButton()
             }
         }
+        .navigationBarBackButtonHidden()
     }
 }
 


### PR DESCRIPTION
## 변경 사항 (Changes)
+ c22ee23 remove: delete .gitkeep
+ 3c9b4e1 feat: firstOnboarding VM생성 및 기존 로직 분리
+ 0f775eb feat: SecondOnboarding VM생성 및 기존 로직 분리
+ 71b0b87 feat: thirdOnboarding VM생성 및 기존 로직 분리

## 변경 이유 (Reason for Changes)
PawCut 온보딩 플로우에서 View와 ViewModel의 완벽한 1:1 구조를 구축하고, 각 화면의 네비게이션 책임을 ViewModel에 위임하여 관심사 분리를 달성했습니다.

### 주요 특징
```swift
@MainActor
class FirstOnboardingViewModel: ObservableObject {
    private let navigationManager = NavigationManager.shared
    let currentPage: Int = 0
    
    func tapNextButton() {
        navigationManager.navigate(to: .onboarding(.secondOnboarding))
    }
}
```

### 아키텍처 설계
- **View 1:1 ViewModel**: 각 온보딩 단계마다 전용 ViewModel 보유
- **NavigationManager 캡슐화**: View는 NavigationManager를 직접 참조하지 않음
- **상태 관리 통합**: 기존 값 및 로직을 ViewModel에서 관리

### 온보딩 플로우
```
FirstOnboarding (currentPage: 0) → SecondOnboarding (currentPage: 1) → ThirdOnboarding (currentPage: 2) → Main
```

## 주요 구현 내용

### 1. ViewModel 기반 네비게이션
```swift
struct FirstOnboardingView: View {
    @StateObject private var viewModel = FirstOnboardingViewModel()
    
    var body: some View {
        PawPrimaryButton("다음") {
            viewModel.tapNextButton()  // View는 ViewModel에만 의존
        }
    }
}
```

### 2. 단계별 상태 관리
```swift
// FirstOnboarding: currentPage = 0
// SecondOnboarding: currentPage = 1  
// ThirdOnboarding: currentPage = 2
PageControl(numberOfPages: 3, currentPage: viewModel.currentPage)
```

## 관련 이슈 (Related Issue)
+ closes #37 

## 테스트 방법 (How to Test)
1. 앱 최초 실행 시 FirstOnboarding 화면 확인
2. "다음" 버튼 클릭으로 SecondOnboarding 이동 확인
3. "다음" 버튼 클릭으로 ThirdOnboarding 이동 확인  
4. 마지막 "다음" 버튼 클릭으로 Main 화면 이동 확인
5. 각 단계에서 PageControl 상태 (0, 1, 2) 확인
6. navigationBarBackButtonHidden으로 뒤로가기 버튼 숨김 확인

## 추가 정보 (Additional Information)
- 각 화면의 네비게이션 로직이 해당 ViewModel에 캡슐화됨

### 향후 개선 계획
- ThirdOnboarding에서 온보딩 완료 처리 로직 추가