### PR TITLE
[Feature] Calendar Component 기능 구현

### DIFF
--- a/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/CalendarMockData.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/CalendarMockData.swift
@@ -1,0 +1,87 @@
+//
+//  CalendarMockData.swift
+//  PawCut
+//
+//  Created by taeni on 8/11/25.
+//
+
+import Foundation
+
+// MARK: - Mock Data Extension
+extension CalendarMockData {
+    
+    /// 랜덤한 날짜에 사진이 있는 Mock 데이터 생성
+    /// - Parameters:
+    ///   - days: 과거 며칠까지 생성할지 (기본값: 30일)
+    ///   - probability: 사진이 있을 확률 (0.0~1.0, 기본값: 0.5)
+    ///   - prefix: 파일명 접두사 (기본값: "mock_photo_")
+    /// - Returns: [Date: String] 형태의 이미지 맵
+    static func randomDateImages(
+        pastDays days: Int = 30,
+        probability: Double = 0.5,
+        filePrefix prefix: String = "mock_photo_"
+    ) -> [Date: String] {
+        let calendar = Calendar.current
+        var images: [Date: String] = [:]
+        
+        for i in 0..<days {
+            if Double.random(in: 0...1) < probability {
+                let date = calendar.date(byAdding: .day, value: -i, to: Date())!
+                let normalizedDate = calendar.startOfDay(for: date)
+                images[normalizedDate] = "\(prefix)\(i).jpg"
+            }
+        }
+        
+        return images
+    }
+    
+    /// 규칙적인 간격으로 사진이 있는 Mock 데이터 생성
+    /// - Parameters:
+    ///   - days: 과거 며칠까지 생성할지
+    ///   - interval: 몇 일 간격으로 사진을 배치할지 (기본값: 3일)
+    ///   - prefix: 파일명 접두사 (기본값: "photo_")
+    /// - Returns: [Date: String] 형태의 이미지 맵
+    static func intervalDateImages(
+        pastDays days: Int = 30,
+        interval: Int = 3,
+        filePrefix prefix: String = "photo_"
+    ) -> [Date: String] {
+        let calendar = Calendar.current
+        var images: [Date: String] = [:]
+        
+        for i in 0..<days {
+            if i % interval == 0 {
+                let date = calendar.date(byAdding: .day, value: -i, to: Date())!
+                let normalizedDate = calendar.startOfDay(for: date)
+                images[normalizedDate] = "\(prefix)\(i).jpg"
+            }
+        }
+        
+        return images
+    }
+    
+    /// 특정 날짜들에 사진이 있는 Mock 데이터 생성
+    /// - Parameters:
+    ///   - dayOffsets: 오늘부터 몇 일 전인지 배열 (예: [0, 1, 3, 7])
+    ///   - prefix: 파일명 접두사
+    /// - Returns: [Date: String] 형태의 이미지 맵
+    static func specificDateImages(
+        dayOffsets: [Int],
+        filePrefix prefix: String = "photo_"
+    ) -> [Date: String] {
+        let calendar = Calendar.current
+        var images: [Date: String] = [:]
+        
+        for offset in dayOffsets {
+            let date = calendar.date(byAdding: .day, value: -offset, to: Date())!
+            let normalizedDate = calendar.startOfDay(for: date)
+            images[normalizedDate] = "\(prefix)\(offset).jpg"
+        }
+        
+        return images
+    }
+}
+
+struct CalendarMockData {
+    private init() {} // 인스턴스 생성 방지
+}

--- a/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/PawCalendarConfiguration.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/PawCalendarConfiguration.swift
@@ -1,0 +1,181 @@
+//
+//  PawCalendarConfiguration.swift
+//  PawCut
+//
+//  Created by taeni on 8/11/25.
+//
+
+import SwiftUI
+import Foundation
+
+struct PawCalendarConfiguration {
+    
+    enum SelectionMode {
+        case single        // 단일 날짜만 선택 가능
+        case range         // 범위 선택 (시작일~종료일)
+        case multiple      // 여러 날짜 동시 선택
+        case readonly      // 읽기 전용 (선택 불가, 표시만)
+        case navigate      // 날짜 선택 시 Navigate 모드 (날짜 선택 시 콜백 호출)
+    }
+    
+    struct DateRange {
+        let startDate: Date?
+        let endDate: Date?
+        
+        var isComplete: Bool {
+            startDate != nil && endDate != nil
+        }
+        
+        static let empty = DateRange(startDate: nil, endDate: nil)
+    }
+    
+    struct DisplayRange {
+        let startDate: Date
+        let endDate: Date
+        
+        static func aroundToday(years: Int = 2) -> DisplayRange {
+            let calendar = Calendar.current
+            let now = Date()
+            let start = calendar.date(byAdding: .year, value: -years, to: now) ?? now
+            let end = calendar.date(byAdding: .year, value: years, to: now) ?? now
+            return DisplayRange(startDate: start, endDate: end)
+        }
+        
+        static func months(from startYear: Int, startMonth: Int, to endYear: Int, endMonth: Int) -> DisplayRange {
+            let calendar = Calendar.current
+            let startComponents = DateComponents(year: startYear, month: startMonth, day: 1)
+            let endComponents = DateComponents(year: endYear, month: endMonth, day: 1)
+            
+            let startDate = calendar.date(from: startComponents) ?? Date()
+            let tempEndDate = calendar.date(from: endComponents) ?? Date()
+            let endDate = calendar.dateInterval(of: .month, for: tempEndDate)?.end ?? tempEndDate
+            
+            return DisplayRange(startDate: startDate, endDate: endDate)
+        }
+        
+        func contains(_ date: Date) -> Bool {
+            return date >= startDate && date <= endDate
+        }
+        
+        var monthOffsetRange: ClosedRange<Int> {
+            let calendar = Calendar.current
+            let now = Date()
+            let startComponents = calendar.dateComponents([.month], from: now, to: startDate)
+            let endComponents = calendar.dateComponents([.month], from: now, to: endDate)
+            
+            let startOffset = startComponents.month ?? 0
+            let endOffset = endComponents.month ?? 0
+            
+            return startOffset...endOffset
+        }
+    }
+    
+    struct Appearance {
+        let primaryColor: Color
+        let backgroundColor: Color
+        let weekColor: Color
+        let dayColor: Color
+        let selectedTextColor: Color
+        let disabledTextColor: Color
+        let todayColor: Color
+        let rangeBackgroundColor: Color
+        let dayTextFont: Font
+        let headerFont: Font
+        let weekdayFont: Font
+        let cellSize: CGFloat
+        let cornerRadius: CGFloat
+        
+        static let pawCutTheme = Appearance(
+            primaryColor: .grayScale01,
+            backgroundColor: .white,
+            weekColor: .grayScale03,
+            dayColor: .grayScale01,
+            selectedTextColor: .grayScale05,
+            disabledTextColor: .grayScale04,
+            todayColor: .clear,
+            rangeBackgroundColor: .grayScale05,
+            dayTextFont: PawButtonStyle.semi14.font,
+            headerFont: PawButtonStyle.semi16.font,
+            weekdayFont: PawButtonStyle.med12.font,
+            cellSize: 40,
+            cornerRadius: 20
+        )
+    }
+    
+    let selectionMode: SelectionMode
+    let appearance: Appearance
+    let displayRange: DisplayRange?
+    let minDate: Date?
+    let maxDate: Date?
+    let highlightedDates: Set<Date>
+    let disabledDates: Set<Date>
+    let dateImages: [Date: String]
+    let onNavigate: ((Date) -> Void)?
+    
+    var effectiveDisplayRange: DisplayRange {
+        return displayRange ?? .aroundToday()
+    }
+    
+    init(
+        selectionMode: SelectionMode = .single,
+        appearance: Appearance = .pawCutTheme,
+        displayRange: DisplayRange? = nil,
+        minDate: Date? = nil,
+        maxDate: Date? = nil,
+        highlightedDates: Set<Date> = [],
+        disabledDates: Set<Date> = [],
+        dateImages: [Date: String] = [:],
+        onNavigate: ((Date) -> Void)? = nil
+    ) {
+        self.selectionMode = selectionMode
+        self.appearance = appearance
+        self.displayRange = displayRange
+        self.minDate = minDate
+        self.maxDate = maxDate
+        self.highlightedDates = highlightedDates
+        self.disabledDates = disabledDates
+        self.dateImages = dateImages
+        self.onNavigate = onNavigate
+    }
+}
+
+// MARK: - 편의 생성자들
+extension PawCalendarConfiguration {
+    
+    static func singleSelection(
+        from startYear: Int, startMonth: Int,
+        to endYear: Int, endMonth: Int
+    ) -> PawCalendarConfiguration {
+        return PawCalendarConfiguration(
+            selectionMode: .single,
+            displayRange: .months(from: startYear, startMonth: startMonth,
+                                  to: endYear, endMonth: endMonth)
+        )
+    }
+    
+    static func rangeSelection(
+        from startYear: Int, startMonth: Int,
+        to endYear: Int, endMonth: Int
+    ) -> PawCalendarConfiguration {
+        return PawCalendarConfiguration(
+            selectionMode: .range,
+            displayRange: .months(from: startYear, startMonth: startMonth,
+                                  to: endYear, endMonth: endMonth)
+        )
+    }
+    
+    static func navigationMode(
+        from startYear: Int, startMonth: Int,
+        to endYear: Int, endMonth: Int,
+        dateImages: [Date: String] = [:],
+        onNavigate: @escaping (Date) -> Void
+    ) -> PawCalendarConfiguration {
+        return PawCalendarConfiguration(
+            selectionMode: .navigate,
+            displayRange: .months(from: startYear, startMonth: startMonth,
+                                  to: endYear, endMonth: endMonth),
+            dateImages: dateImages,
+            onNavigate: onNavigate
+        )
+    }
+}

--- a/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/PawCalendarDay.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/PawCalendarDay.swift
@@ -1,0 +1,24 @@
+//
+//  PawCalendarDay.swift
+//  PawCut
+//
+//  Created by taeni on 8/11/25.
+//
+
+import Foundation
+
+struct PawCalendarDay: Identifiable {
+    let id = UUID()
+    let date: Date
+    let day: Int
+    let isCurrentMonth: Bool
+    let isToday: Bool
+    let isSelected: Bool
+    let isHighlighted: Bool
+    let isDisabled: Bool
+    let isInRange: Bool
+    let hasImage: Bool
+    let imageName: String?
+    let isStartDate: Bool
+    let isEndDate: Bool
+}

--- a/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/PawCalendarPreview.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/PawCalendarPreview.swift
@@ -1,0 +1,320 @@
+//
+//  PawCalendarPreview.swift
+//  PawCut
+//
+//  Created by taeni on 8/11/25.
+//
+
+import SwiftUI
+
+// MARK: - Preview Examples
+#Preview("기본 캘린더") {
+    PawCalendarView.defaultCalendar { date in
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        print("기본 캘린더 선택: \(formatter.string(from: date))")
+    }
+    .frame(maxHeight: .infinity)
+    .padding(.vertical)
+}
+
+#Preview("범위 선택 캘린더") {
+    RangeSelectionPreview()
+        .frame(maxHeight: .infinity)
+        .padding(.vertical)
+}
+
+#Preview("다중 선택 캘린더") {
+    MultipleSelectionPreview()
+        .frame(maxHeight: .infinity)
+        .padding(.vertical)
+}
+
+#Preview("네비게이션 모드 (사진 있는 날짜)") {
+    NavigationPreview()
+        .frame(maxHeight: .infinity)
+        .padding(.vertical)
+}
+
+#Preview("커스텀 테마") {
+    let customAppearance = PawCalendarConfiguration.Appearance(
+        primaryColor: .pointPurple01,
+        backgroundColor: .white,
+        weekColor: .grayScale03,
+        dayColor: .grayScale01,
+        selectedTextColor: .white,
+        disabledTextColor: .grayScale04,
+        todayColor: .pointPurple01,
+        rangeBackgroundColor: .pointPurple02,
+        dayTextFont: FontSet.pretendard(size: ._14, weight: .semibold),
+        headerFont: FontSet.pretendard(size: ._18, weight: .bold),
+        weekdayFont: FontSet.pretendard(size: ._12, weight: .medium),
+        cellSize: 45,
+        cornerRadius: 22
+    )
+    
+    let customConfig = PawCalendarConfiguration(
+        selectionMode: .multiple,
+        appearance: customAppearance,
+        displayRange: .months(from: 2024, startMonth: 6, to: 2025, endMonth: 12)
+    )
+    
+    PawCalendarView.custom(configuration: customConfig) { date in
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        print("커스텀 캘린더 선택: \(formatter.string(from: date))")
+    }
+}
+
+// MARK: - 범위 선택 Preview
+struct RangeSelectionPreview: View {
+    @State private var selectedRange: PawCalendarConfiguration.DateRange = .empty
+    
+    var body: some View {
+        PawCalendarView.withDateRange(
+            from: 2024, startMonth: 1,
+            to: 2026, endMonth: 12,
+            selectionMode: .range
+        ) { date in
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd"
+            
+            if selectedRange.startDate == nil {
+                // 시작일 선택
+                selectedRange = PawCalendarConfiguration.DateRange(startDate: date, endDate: nil)
+                print("시작일 선택: \(formatter.string(from: date))")
+            } else if selectedRange.endDate == nil {
+                // 종료일 선택
+                if let startDate = selectedRange.startDate {
+                    if date >= startDate {
+                        selectedRange = PawCalendarConfiguration.DateRange(startDate: startDate, endDate: date)
+                        print("범위 완성: \(formatter.string(from: startDate)) ~ \(formatter.string(from: date))")
+                    } else {
+                        // 시작일보다 이전 날짜 선택 시 시작일 재설정
+                        selectedRange = PawCalendarConfiguration.DateRange(startDate: date, endDate: nil)
+                        print("시작일 재선택: \(formatter.string(from: date))")
+                    }
+                }
+            } else {
+                // 이미 범위가 완성된 상태에서 새로운 시작일 선택
+                selectedRange = PawCalendarConfiguration.DateRange(startDate: date, endDate: nil)
+                print("새로운 시작일 선택: \(formatter.string(from: date))")
+            }
+        }
+    }
+}
+
+// MARK: - 네비게이션 Preview
+struct NavigationPreview: View {
+    @State private var navigationPath = NavigationPath()
+    
+    // 예시 mock data
+    private let mockDateImages = CalendarMockData.randomDateImages(pastDays: 30, probability: 0.5)
+    
+    var body: some View {
+        NavigationStack(path: $navigationPath) {
+            PawCalendarView.navigation(
+                from: 2025, startMonth: 1,
+                to: 2025, endMonth: 8,
+                dateImages: mockDateImages
+            ) { date in
+                // 사진이 있는 날짜만 처리
+                if let imageName = mockDateImages[date] {
+                    let formatter = DateFormatter()
+                    formatter.dateFormat = "yyyy-MM-dd"
+                    print("네비게이션 선택 (사진 있음): \(formatter.string(from: date)) - \(imageName)")
+                    
+                    navigationPath.append(PhotoDestination(date: date, imageName: imageName))
+                }
+            }
+            .navigationDestination(for: PhotoDestination.self) { destination in
+                PhotoDetailView(
+                    selectedDate: destination.date,
+                    imageName: destination.imageName
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Photo Destination
+struct PhotoDestination: Hashable {
+    let date: Date
+    let imageName: String
+}
+
+// MARK: - 사진 상세 뷰 (예제)
+struct PhotoDetailView: View {
+    let selectedDate: Date
+    let imageName: String
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            // 날짜 표시
+            Text(dateString)
+                .font(.title2)
+                .fontWeight(.bold)
+            
+            // Mock 이미지 (실제로는 AsyncImage 사용)
+            Rectangle()
+                .fill(
+                    LinearGradient(
+                        colors: [.blue.opacity(0.6), .purple.opacity(0.6)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: 300, height: 300)
+                .cornerRadius(12)
+                .overlay(
+                    VStack {
+                        Image(systemName: "photo")
+                            .font(.system(size: 60))
+                            .foregroundColor(.white)
+                        
+                        Text(imageName)
+                            .foregroundColor(.white)
+                            .font(.caption)
+                    }
+                )
+            
+            Text("이 날의 사진입니다!")
+                .font(.body)
+                .foregroundColor(.secondary)
+            
+            Spacer()
+        }
+        .padding()
+        .navigationTitle("사진 보기")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private var dateString: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월 d일"
+        return formatter.string(from: selectedDate)
+    }
+}
+struct MultipleSelectionPreview: View {
+    @State private var selectedDates: Set<Date> = []
+    
+    var body: some View {
+        PawCalendarView.withDateRange(
+            from: 2024, startMonth: 1,
+            to: 2026, endMonth: 12,
+            selectionMode: .multiple
+        ) { date in
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd"
+            
+            if selectedDates.contains(date) {
+                selectedDates.remove(date)
+                print("날짜 제거: \(formatter.string(from: date))")
+            } else {
+                selectedDates.insert(date)
+                print("날짜 추가: \(formatter.string(from: date))")
+            }
+            
+            // 선택된 모든 날짜를 정렬해서 출력
+            let sortedDates = selectedDates.sorted()
+            let dateStrings = sortedDates.map { formatter.string(from: $0) }
+            print("선택된 모든 날짜: \(dateStrings)")
+        }
+    }
+}
+
+// MARK: - 사용 예제 뷰
+struct CalendarExampleView: View {
+    @State private var selectedMode: SelectionMode = .single
+    
+    enum SelectionMode: String, CaseIterable {
+        case single = "단일 선택"
+        case range = "범위 선택"
+        case multiple = "다중 선택"
+        case navigate = "네비게이션"
+    }
+    
+    var body: some View {
+        VStack {
+            // 모드 선택
+            Picker("Selection Mode", selection: $selectedMode) {
+                ForEach(SelectionMode.allCases, id: \.self) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            .padding()
+            
+            // 캘린더
+            Group {
+                switch selectedMode {
+                case .single:
+                    singleSelectionCalendar
+                case .range:
+                    RangeSelectionPreview()
+                case .multiple:
+                    MultipleSelectionPreview()
+                case .navigate:
+                    navigationCalendar
+                }
+            }
+            .frame(maxHeight: .infinity)
+            
+            Spacer()
+        }
+        .navigationTitle("PawCalendar 예제")
+    }
+    
+    private var singleSelectionCalendar: some View {
+        PawCalendarView.withDateRange(
+            from: 2024, startMonth: 1,
+            to: 2026, endMonth: 12,
+            selectionMode: .single
+        ) { date in
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd"
+            print("단일 선택: \(formatter.string(from: date))")
+        }
+    }
+    
+    private var navigationCalendar: some View {
+        NavigationCalendarExample()
+    }
+}
+
+// MARK: - 사용 예제의 네비게이션 캘린더
+struct NavigationCalendarExample: View {
+    @State private var navigationPath = NavigationPath()
+    
+    private let mockImages = CalendarMockData.intervalDateImages(pastDays: 20, interval: 3, filePrefix: "photo_")
+    
+    var body: some View {
+        PawCalendarView.navigation(
+            from: 2024, startMonth: 1,
+            to: 2026, endMonth: 12,
+            dateImages: mockImages
+        ) { date in
+            // 사진이 있는 날짜만 처리
+            if let imageName = mockImages[date] {
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy-MM-dd"
+                print("네비게이션 선택 (사진 있음): \(formatter.string(from: date)) - \(imageName)")
+                
+                navigationPath.append(PhotoDestination(date: date, imageName: imageName))
+            }
+        }
+        .navigationDestination(for: PhotoDestination.self) { destination in
+            PhotoDetailView(
+                selectedDate: destination.date,
+                imageName: destination.imageName
+            )
+        }
+    }
+}
+
+#Preview("사용 예제") {
+    NavigationStack {
+        CalendarExampleView()
+    }
+}

--- a/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/PawCalendarPreview.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/PawCalendarPreview.swift
@@ -124,11 +124,11 @@ struct NavigationPreview: View {
                     formatter.dateFormat = "yyyy-MM-dd"
                     print("네비게이션 선택 (사진 있음): \(formatter.string(from: date)) - \(imageName)")
                     
-                    navigationPath.append(PhotoDestination(date: date, imageName: imageName))
+                    navigationPath.append(PhotoPreviewDestination(date: date, imageName: imageName))
                 }
             }
-            .navigationDestination(for: PhotoDestination.self) { destination in
-                PhotoDetailView(
+            .navigationDestination(for: PhotoPreviewDestination.self) { destination in
+                PhotoDetailPreview(
                     selectedDate: destination.date,
                     imageName: destination.imageName
                 )
@@ -138,13 +138,13 @@ struct NavigationPreview: View {
 }
 
 // MARK: - Photo Destination
-struct PhotoDestination: Hashable {
+struct PhotoPreviewDestination: Hashable {
     let date: Date
     let imageName: String
 }
 
 // MARK: - 사진 상세 뷰 (예제)
-struct PhotoDetailView: View {
+struct PhotoDetailPreview: View {
     let selectedDate: Date
     let imageName: String
     
@@ -154,39 +154,8 @@ struct PhotoDetailView: View {
             Text(dateString)
                 .font(.title2)
                 .fontWeight(.bold)
-            
-            // Mock 이미지 (실제로는 AsyncImage 사용)
-            Rectangle()
-                .fill(
-                    LinearGradient(
-                        colors: [.blue.opacity(0.6), .purple.opacity(0.6)],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                )
-                .frame(width: 300, height: 300)
-                .cornerRadius(12)
-                .overlay(
-                    VStack {
-                        Image(systemName: "photo")
-                            .font(.system(size: 60))
-                            .foregroundColor(.white)
-                        
-                        Text(imageName)
-                            .foregroundColor(.white)
-                            .font(.caption)
-                    }
-                )
-            
-            Text("이 날의 사진입니다!")
-                .font(.body)
-                .foregroundColor(.secondary)
-            
             Spacer()
         }
-        .padding()
-        .navigationTitle("사진 보기")
-        .navigationBarTitleDisplayMode(.inline)
     }
     
     private var dateString: String {
@@ -256,7 +225,7 @@ struct CalendarExampleView: View {
                 case .multiple:
                     MultipleSelectionPreview()
                 case .navigate:
-                    navigationCalendar
+                    NavigationPreview()
                 }
             }
             .frame(maxHeight: .infinity)
@@ -276,10 +245,6 @@ struct CalendarExampleView: View {
             formatter.dateFormat = "yyyy-MM-dd"
             print("단일 선택: \(formatter.string(from: date))")
         }
-    }
-    
-    private var navigationCalendar: some View {
-        NavigationCalendarExample()
     }
 }
 
@@ -301,11 +266,11 @@ struct NavigationCalendarExample: View {
                 formatter.dateFormat = "yyyy-MM-dd"
                 print("네비게이션 선택 (사진 있음): \(formatter.string(from: date)) - \(imageName)")
                 
-                navigationPath.append(PhotoDestination(date: date, imageName: imageName))
+                navigationPath.append(PhotoPreviewDestination(date: date, imageName: imageName))
             }
         }
-        .navigationDestination(for: PhotoDestination.self) { destination in
-            PhotoDetailView(
+        .navigationDestination(for: PhotoPreviewDestination.self) { destination in
+            PhotoDetailPreview(
                 selectedDate: destination.date,
                 imageName: destination.imageName
             )

--- a/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/PawCalendarView+.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/PawCalendarView+.swift
@@ -1,0 +1,267 @@
+//
+//  PawCalendarView+.swift
+//  PawCut
+//
+//  Created by taeni on 8/11/25.
+//
+
+import SwiftUI
+import Foundation
+
+// MARK: - Computed Properties
+extension PawCalendarView {
+    
+    var monthOffsetRange: ClosedRange<Int> {
+        return configuration.effectiveDisplayRange.monthOffsetRange
+    }
+    
+    var currentDisplayDate: Date {
+        return calendar.date(byAdding: .month, value: scrollPosition, to: Date()) ?? Date()
+    }
+}
+
+// MARK: - Date Selection Logic
+extension PawCalendarView {
+    
+    func handleDateSelection(_ date: Date) {
+        // 날짜 선택 시 정규화된 날짜 사용 (시간 부분 제거)
+        let normalizedDate = calendar.startOfDay(for: date)
+        
+        switch configuration.selectionMode {
+        case .single:
+            selectedDate = normalizedDate
+        case .range:
+            handleRangeSelection(normalizedDate)
+        case .multiple:
+            handleMultipleSelection(normalizedDate)
+        case .navigate:
+            configuration.onNavigate?(normalizedDate)
+        case .readonly:
+            break
+        }
+    }
+    
+    private func handleRangeSelection(_ date: Date) {
+        let normalizedDate = calendar.startOfDay(for: date)
+        
+        if selectedRange.startDate == nil {
+            selectedRange = PawCalendarConfiguration.DateRange(startDate: normalizedDate, endDate: nil)
+        } else if selectedRange.endDate == nil {
+            guard let startDate = selectedRange.startDate else { return }
+            
+            if normalizedDate >= startDate {
+                selectedRange = PawCalendarConfiguration.DateRange(startDate: startDate, endDate: normalizedDate)
+            } else {
+                selectedRange = PawCalendarConfiguration.DateRange(startDate: normalizedDate, endDate: nil)
+            }
+        } else {
+            selectedRange = PawCalendarConfiguration.DateRange(startDate: normalizedDate, endDate: nil)
+        }
+    }
+    
+    private func handleMultipleSelection(_ date: Date) {
+        let normalizedDate = calendar.startOfDay(for: date)
+        
+        if selectedDates.contains(normalizedDate) {
+            selectedDates.remove(normalizedDate)
+        } else {
+            selectedDates.insert(normalizedDate)
+        }
+    }
+}
+
+// MARK: - Calendar Generation
+extension PawCalendarView {
+    
+    func generateDaysForMonth(offset: Int) -> [PawCalendarDay] {
+        guard let targetDate = calendar.date(byAdding: .month, value: offset, to: Date()) else {
+            return []
+        }
+        
+        return generateCalendarDays(for: targetDate)
+    }
+    
+    private func generateCalendarDays(for targetDate: Date) -> [PawCalendarDay] {
+        var days: [PawCalendarDay] = []
+        
+        // 현재 월의 시작일과 끝일 계산
+        let monthInterval = calendar.dateInterval(of: .month, for: targetDate)!
+        let firstDay = monthInterval.start
+        
+        // 첫 주의 시작일 계산 (일요일부터 시작)
+        let firstWeekday = calendar.component(.weekday, from: firstDay)
+        let startOfWeek = calendar.date(byAdding: .day, value: -(firstWeekday - 1), to: firstDay)!
+        
+        // 해당 월에 필요한 주 수 계산
+        let lastDay = calendar.date(byAdding: .day, value: -1, to: monthInterval.end)!
+        let weeksNeeded = (calendar.component(.day, from: lastDay) + firstWeekday - 2) / 7 + 1
+        let totalDays = weeksNeeded * 7
+        
+        // 날짜 생성
+        for i in 0..<totalDays {
+            guard let date = calendar.date(byAdding: .day, value: i, to: startOfWeek) else { continue }
+            
+            let day = calendar.component(.day, from: date)
+            let isCurrentMonth = calendar.isDate(date, equalTo: targetDate, toGranularity: .month)
+            let isToday = calendar.isDateInToday(date)
+            let normalizedDate = calendar.startOfDay(for: date)
+            
+            let calendarDay = PawCalendarDay(
+                date: date,
+                day: day,
+                isCurrentMonth: isCurrentMonth,
+                isToday: isToday,
+                isSelected: isDateSelected(date),
+                isHighlighted: configuration.highlightedDates.contains(normalizedDate),
+                isDisabled: isDateDisabled(date),
+                isInRange: isDateInSelectedRange(date),
+                hasImage: configuration.dateImages[normalizedDate] != nil,
+                imageName: configuration.dateImages[normalizedDate],
+                isStartDate: isDateRangeStartDate(date),
+                isEndDate: isDateRangeEndDate(date)
+            )
+            
+            days.append(calendarDay)
+        }
+        
+        return days
+    }
+}
+
+// MARK: - Date State Checking
+extension PawCalendarView {
+    
+    private func isDateSelected(_ date: Date) -> Bool {
+        let normalizedDate = calendar.startOfDay(for: date)
+        
+        switch configuration.selectionMode {
+        case .single:
+            guard let selected = selectedDate else { return false }
+            return calendar.isDate(normalizedDate, inSameDayAs: selected)
+        case .range:
+            return isDateRangeEndpoint(date)
+        case .multiple:
+            return selectedDates.contains(normalizedDate)
+        case .navigate, .readonly:
+            return false
+        }
+    }
+    
+    private func isDateRangeEndpoint(_ date: Date) -> Bool {
+        return isDateRangeStartDate(date) || isDateRangeEndDate(date)
+    }
+    
+    private func isDateRangeStartDate(_ date: Date) -> Bool {
+        guard let startDate = selectedRange.startDate else { return false }
+        return calendar.isDate(date, inSameDayAs: startDate)
+    }
+    
+    private func isDateRangeEndDate(_ date: Date) -> Bool {
+        guard let endDate = selectedRange.endDate else { return false }
+        return calendar.isDate(date, inSameDayAs: endDate)
+    }
+    
+    private func isDateInSelectedRange(_ date: Date) -> Bool {
+        guard configuration.selectionMode == .range,
+              let startDate = selectedRange.startDate,
+              let endDate = selectedRange.endDate else {
+            return false
+        }
+        
+        let normalizedDate = calendar.startOfDay(for: date)
+        let normalizedStart = calendar.startOfDay(for: startDate)
+        let normalizedEnd = calendar.startOfDay(for: endDate)
+        
+        return normalizedDate > normalizedStart && normalizedDate < normalizedEnd
+    }
+    
+    private func isDateDisabled(_ date: Date) -> Bool {
+        let normalizedDate = calendar.startOfDay(for: date)
+        
+        // 표시 범위 밖인 경우
+        if !configuration.effectiveDisplayRange.contains(date) {
+            return true
+        }
+        
+        // 설정된 비활성화 날짜
+        if configuration.disabledDates.contains(normalizedDate) {
+            return true
+        }
+        
+        // 최소/최대 날짜 범위 확인
+        if let minDate = configuration.minDate, normalizedDate < calendar.startOfDay(for: minDate) {
+            return true
+        }
+        
+        if let maxDate = configuration.maxDate, normalizedDate > calendar.startOfDay(for: maxDate) {
+            return true
+        }
+        
+        return false
+    }
+}
+
+// MARK: - Utility Methods
+extension PawCalendarView {
+    
+    func monthYearString(for offset: Int) -> String {
+        guard let targetDate = calendar.date(byAdding: .month, value: offset, to: Date()) else {
+            return ""
+        }
+        
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월"
+        return formatter.string(from: targetDate)
+    }
+    
+    func scrollToDate(_ date: Date) {
+        let components = calendar.dateComponents([.month], from: Date(), to: date)
+        if let monthOffset = components.month {
+            scrollPosition = monthOffset
+        }
+    }
+    
+    func scrollToToday() {
+        scrollPosition = 0
+    }
+    
+    func clearSelection() {
+        selectedDate = nil
+        selectedRange = .empty
+        selectedDates.removeAll()
+    }
+}
+
+// MARK: - Static Factory Methods
+extension PawCalendarView {
+    
+    static func defaultCalendar(onDateSelected: ((Date) -> Void)? = nil) -> PawCalendarView {
+        return PawCalendarView(onDateSelected: onDateSelected)
+    }
+    
+    static func custom(configuration: PawCalendarConfiguration, onDateSelected: ((Date) -> Void)? = nil) -> PawCalendarView {
+        return PawCalendarView(configuration: configuration, onDateSelected: onDateSelected)
+    }
+    
+    static func withDateRange(from startYear: Int, startMonth: Int, to endYear: Int, endMonth: Int,
+                              selectionMode: PawCalendarConfiguration.SelectionMode = .single, onDateSelected: ((Date) -> Void)? = nil) -> PawCalendarView {
+        let config = PawCalendarConfiguration(
+            selectionMode: selectionMode,
+            displayRange: .months(from: startYear, startMonth: startMonth,
+                                  to: endYear, endMonth: endMonth)
+        )
+        return PawCalendarView(configuration: config, onDateSelected: onDateSelected)
+    }
+    
+    static func navigation(from startYear: Int, startMonth: Int, to endYear: Int, endMonth: Int,
+                           dateImages: [Date: String] = [:], onNavigate: @escaping (Date) -> Void) -> PawCalendarView {
+        let config = PawCalendarConfiguration.navigationMode(
+            from: startYear, startMonth: startMonth,
+            to: endYear, endMonth: endMonth,
+            dateImages: dateImages,
+            onNavigate: onNavigate
+        )
+        return PawCalendarView(configuration: config)
+    }
+}

--- a/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/PawCalendarView.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Calendar/PawCalendarView.swift
@@ -1,0 +1,230 @@
+//
+//  PawCalendarView.swift
+//  PawCut
+//
+//  Created by taeni on 8/11/25.
+//
+
+import SwiftUI
+
+struct PawCalendarView: View {
+    
+    // MARK: - Properties
+    let configuration: PawCalendarConfiguration
+    let onDateSelected: ((Date) -> Void)?
+    
+    @State var selectedDate: Date?
+    @State var selectedRange: PawCalendarConfiguration.DateRange = .empty
+    @State var selectedDates: Set<Date> = []
+    @State var scrollPosition: Int = 0
+    
+    let calendar = Calendar.current
+    let weekdaySymbols = ["일", "월", "화", "수", "목", "금", "토"]
+    
+    // MARK: - Initializer
+    init(
+        configuration: PawCalendarConfiguration = PawCalendarConfiguration(),
+        onDateSelected: ((Date) -> Void)? = nil
+    ) {
+        self.configuration = configuration
+        self.onDateSelected = onDateSelected
+    }
+    
+    // MARK: - Body
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollViewReader { proxy in
+                ScrollView(.vertical, showsIndicators: false) {
+                    LazyVStack(spacing: 0) {
+                        ForEach(Array(monthOffsetRange), id: \.self) { monthOffset in
+                            monthView(for: monthOffset)
+                                .id(monthOffset)
+                        }
+                    }
+                }
+                .onAppear {
+                    DispatchQueue.main.async {
+                        proxy.scrollTo(scrollPosition, anchor: .top)
+                    }
+                }
+                .onChange(of: scrollPosition) { _, newPosition in
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        proxy.scrollTo(newPosition, anchor: .top)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 20)
+        .background(configuration.appearance.backgroundColor)
+    }
+    
+    // MARK: - Subviews
+    private var weekdayHeaderView: some View {
+        HStack(spacing: 0) {
+            ForEach(weekdaySymbols, id: \.self) { weekday in
+                Text(weekday)
+                    .font(configuration.appearance.weekdayFont)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(configuration.appearance.weekColor)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(.vertical, 10)
+    }
+    
+    private func monthView(for monthOffset: Int) -> some View {
+        let days = generateDaysForMonth(offset: monthOffset)
+        
+        return VStack(spacing: 0) {
+            monthHeaderView(for: monthOffset)
+            
+            weekdayHeaderView
+                .background(configuration.appearance.backgroundColor)
+            
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible()), count: 7)
+            ) {
+                ForEach(days) { day in
+                    PawCalendarDayView(
+                        day: day,
+                        configuration: configuration,
+                        onTap: {
+                            let normalizedDate = calendar.startOfDay(for: day.date)
+                            handleDateSelection(day.date)
+                            onDateSelected?(normalizedDate)
+                        }
+                    )
+                    .frame(width: 40)
+                }
+            }
+            .padding(.bottom, 20)
+        }
+    }
+    
+    private func monthHeaderView(for monthOffset: Int) -> some View {
+        HStack {
+            Text(monthYearString(for: monthOffset))
+                .font(configuration.appearance.headerFont)
+                .foregroundColor(configuration.appearance.dayColor)
+            
+            Spacer()
+        }
+        .padding(.vertical, 20)
+    }
+}
+
+// MARK: - Day View
+struct PawCalendarDayView: View {
+    let day: PawCalendarDay
+    let configuration: PawCalendarConfiguration
+    let onTap: () -> Void
+    
+    var body: some View {
+        if !day.isCurrentMonth {
+            Color.clear
+                .frame(minHeight: 45)
+        } else {
+            Button(action: {
+                if !day.isDisabled {
+                    onTap()
+                }
+            }) {
+                ZStack {
+                    if day.hasImage {
+                        imageBackgroundView
+                    } else {
+                        defaultBackgroundView
+                    }
+                    
+                    Text("\(day.day)")
+                        .font(configuration.appearance.dayTextFont)
+                        .foregroundColor(textColor)
+                        .shadow(color: day.hasImage ? .black.opacity(0.7) : .clear,
+                                radius: day.hasImage ? 1 : 0,
+                                x: 0, y: 1)
+                }
+            }
+            .frame(minHeight: 45)
+            .buttonStyle(PlainButtonStyle())
+            .disabled(day.isDisabled)
+            .opacity(day.isDisabled ? 0.3 : 1.0)
+        }
+    }
+    
+    private var imageBackgroundView: some View {
+        Circle()
+            .foregroundColor(.pointPurple01)
+            .frame(
+                width: configuration.appearance.cellSize,
+                height: configuration.appearance.cellSize
+            )
+            .overlay(
+                Circle()
+                    .stroke(
+                        day.isToday ? configuration.appearance.todayColor : .clear,
+                        lineWidth: day.isToday ? 2 : 0
+                    )
+            )
+    }
+    
+    private var defaultBackgroundView: some View {
+        ZStack {
+            // 범위 선택 배경
+            if day.isInRange {
+                Rectangle()
+                    .fill(configuration.appearance.rangeBackgroundColor)
+                    .frame(maxHeight: configuration.appearance.cellSize)
+            }
+            
+            // 범위 선택 반원 처리
+            if day.isStartDate || day.isEndDate {
+                rangePartialBackground
+            }
+            
+            // 선택된 날짜 배경
+            if day.isSelected {
+                Circle()
+                    .fill(configuration.appearance.primaryColor)
+                    .frame(width: configuration.appearance.cellSize,
+                           height: configuration.appearance.cellSize)
+            }
+            
+            // 오늘 날짜 테두리
+            if day.isToday && !day.isSelected {
+                Circle()
+                    .stroke(configuration.appearance.todayColor, lineWidth: 2)
+                    .frame(width: configuration.appearance.cellSize,
+                           height: configuration.appearance.cellSize)
+            }
+        }
+    }
+    
+    private var rangePartialBackground: some View {
+        Group {
+            if configuration.selectionMode == .range && (day.isStartDate || day.isEndDate) {
+                let leftColor: Color = day.isStartDate ? .clear : configuration.appearance.rangeBackgroundColor
+                let rightColor: Color = day.isEndDate ? .clear : configuration.appearance.rangeBackgroundColor
+                
+                HStack(spacing: 0) {
+                    leftColor.frame(maxWidth: .infinity)
+                    rightColor.frame(maxWidth: .infinity)
+                }
+                .frame(maxHeight: configuration.appearance.cellSize)
+            }
+        }
+    }
+    
+    private var textColor: Color {
+        if day.isDisabled {
+            return configuration.appearance.disabledTextColor
+        } else if day.isSelected {
+            return configuration.appearance.selectedTextColor
+        } else if day.isInRange {
+            return configuration.appearance.dayColor
+        } else if day.hasImage {
+            return configuration.appearance.selectedTextColor
+        } else {
+            return configuration.appearance.dayColor
+        }
+    }
+}


### PR DESCRIPTION
<!--
PR을 제출하기 전에 다음 사항들을 확인해주세요:
- 제목에 PR의 내용을 명확히 설명했나요?
- 모든 코드를 로컬 환경에서 테스트해 보았나요?
- 관련 문서를 업데이트했나요?
-->

## 변경 사항 (Changes)
<!--
이 PR에서 변경된 내용을 간략하게 설명해주세요.
-->


**ViewModel 로 구현했던 것들을 Extension 방식으로 변경했습니다.**

_PawCalendarConfiguration.swift_
- 캘린더 커스텀 방식은 총 5가지 입니다.
1. 단일 날짜 선택이 가능한 모드
2. 시작~종료일이 있고 이 여부를 검사하는 모드
3. 여러 날짜를 여러개로 받아서 배열에 담는 모드
4. 읽기만 하도록 하는 모드
5. PawCut에서 사용하는 이미지가 있을 경우 상세 화면으로 갈 수 있도록 하는 navigate 모드가 있습니다.

ArchiveView 에서는 navigate 모드로 구현 예정입니다.

> DisplayRange : 캘린더에서 언제부터 언제까지의 달력을 보여줄지 구현합니다. 값이 없을 경우 오늘 기준 2년 전 ~ 2년 후로 보여집니다.
> Appearance : 달력을 그리는 컬러셋과 정보들을 구현합니다. 현재 오늘 날짜 표시는 없기 때문에 .clear 로 적용되어있습니다.
> PawCalendarConfiguration Extension : 간단하게 모드를 구현할 수 있습니다.


_PawCalendarDay.swift_ 
- generateCalendarDays로 만들어지는데, 달력의 날짜에 들어가야할 정보들을 만들어줄 구조체입니다.

_PawCalendarView.swift_
- 달력을 실제로 구현하는 화면입니다.
- Scroll 위치를 잡기 위해 ScrollViewReader 에 감싸져있고 id를 이용해 스크롤을 조정합니다.
- header 가 고정되어있고, 정해진 기간의 달력을 수직 스크롤로 보여줍니다.

_PawCalendarView+.swift_ 
- View 를 구현하기 위한 Extension 파일입니다.
- 달력으로 보여줄 기간 설정 및 보여줄 날짜 설정,
- 날짜 선택 시 어떤 처리를 할 것인지,
- 기간(범위 기간) 유효성 검사,
- 연월일 을 String 으로 포맷 및 스크롤처리 기능이 있습니다.

_PawCalendarPreview.swift_
- 전체적인 모드를 보기 위해 Preview 를 생성했습니다.
- **Destination 도 임시로 추가해두었는데 추후에 Preview 관련 파일들은 다 날리겠습니다!**

## 변경 이유 (Reason for Changes)
<!--
이 변경 사항이 필요한 이유와 문제를 어떻게 해결하는지 설명해주세요.
-->

## 관련 이슈 (Related Issue)
<!--
이 PR이 해결하는 관련 이슈 번호를 참조하세요. 예: #123
-->

#43 

## 테스트 방법 (How to Test)
<!--
변경 사항이 적용되었는지 테스트하기 위해 수행해야 하는 단계를 설명해주세요.
1. Go to '...'
2. Click on '...'
3. Observe '...'
-->

PawCalendarPreview.swift 파일을 참고해주세요.

## 추가 정보 (Additional Information)
<!--
이 PR에 대한 추가적인 정보가 있으면 제공해주세요.
-->

<img width="371" height="740" alt="image" src="https://github.com/user-attachments/assets/f0583f07-d58c-4e63-984a-365c606e50d5" />


https://github.com/user-attachments/assets/402a61f4-5bac-4a18-bb3f-7f5128454c94





