### PR TITLE
[Feature] Pawcut 선택/프레임 뷰 데이터 저장 및 불러오기 로직 개선

### DIFF
--- a/PawCut/PawCut/Sources/ViewModels/PawcutFrame/PawcutFrameViewModel.swift
+++ b/PawCut/PawCut/Sources/ViewModels/PawcutFrame/PawcutFrameViewModel.swift
@@ -7,13 +7,15 @@ class PawcutFrameViewModel: ObservableObject {
     @Published var selectedImages: [UIImage] = []
     @Published var isBottomSheetPresented = false
     @Published var selectedFrameIndex: Int? = nil
-    @Published var frameScrollImageNames: [String] = [
+    
+    var frameScrollImageNames: [String] = [
         "snow_scroll", "ink_scroll", "cobalt_scroll", "peek_scroll",
         "heart_scroll", "cloud_scroll", "blush_scroll", "wave_scroll",
         "sparkle_scroll", "dawn_scroll", "bloom_scroll", "breeze_scroll",
         "blue_scroll", "ginkgo_scroll",
     ]
-    @Published var frameImageNames: [String] = [
+    
+    var frameImageNames: [String] = [
         "snow_frame", "ink_frame", "cobalt_frame", "peek_frame", "heart_frame",
         "cloud_frame", "blush_frame", "wave_frame", "sparkle_frame",
         "dawn_frame", "bloom_frame", "breeze_frame", "blue_frame",
@@ -34,14 +36,28 @@ class PawcutFrameViewModel: ObservableObject {
         return UIImage(named: frameImageNames[index])
     }
 
-    func tapBackButton() {
-        navigationManager.pop()
+    func loadSelectedImages() {
+        if let dataArray = UserDefaults.standard.array(
+            forKey: "pawcut_selected_images"
+        ) as? [Data] {
+            let images = dataArray.compactMap { UIImage(data: $0) }
+            self.selectedImages = images
+            return
+        }
     }
 
     func saveCurrentPawcut(rendered: UIImage) {
         if let data = rendered.jpegData(compressionQuality: 0.9) {
             UserDefaults.standard.set(data, forKey: "pawcut_photo")
-            UserDefaults.standard.set(Date(), forKey: "pawcut_capture_date")
+            UserDefaults.standard.set(Date(), forKey: "pawcut_photo_date")
         }
+    }
+    
+    func tapBackButton() {
+        navigationManager.pop()
+    }
+    
+    func tapHomeButton() {
+        navigationManager.navigate(to: .main(.home))
     }
 }

--- a/PawCut/PawCut/Sources/ViewModels/PawcutSelect/PawcutSelectionViewModel.swift
+++ b/PawCut/PawCut/Sources/ViewModels/PawcutSelect/PawcutSelectionViewModel.swift
@@ -3,10 +3,10 @@ import SwiftUI
 @MainActor
 class PawcutSelectionViewModel: ObservableObject {
     private let navigationManager = NavigationManager.shared
-    
+
     @Published private(set) var sourceImages: [UIImage] = []
     @Published private(set) var selectedIndices: [Int] = []
-    
+
     let maxSelection = 4
 
     var selectedCount: Int { selectedIndices.count }
@@ -14,15 +14,27 @@ class PawcutSelectionViewModel: ObservableObject {
     var selectedImagesInOrder: [UIImage] {
         selectedIndices.map { sourceImages[$0] }
     }
-    
+
     func loadSavedData() {
-        if let dataArray = UserDefaults.standard.array(forKey: "captured_photos") as? [Data] {
+        if let dataArray = UserDefaults.standard.array(
+            forKey: "captured_photos"
+        ) as? [Data] {
             let images = dataArray.compactMap { UIImage(data: $0) }
             sourceImages = images
             selectedIndices.removeAll()
         }
     }
     
+    func saveSelectedImages() {
+        guard selectedIndices.count == maxSelection else { return }
+
+        let dataArray: [Data] = selectedImagesInOrder.compactMap {
+            $0.jpegData(compressionQuality: 0.9)
+        }
+
+        UserDefaults.standard.set(dataArray, forKey: "pawcut_selected_images")
+    }
+
     func toggleSelection(at index: Int) {
         if let i = selectedIndices.firstIndex(of: index) {
             // 이미 선택되어 있으면 해제
@@ -33,20 +45,21 @@ class PawcutSelectionViewModel: ObservableObject {
             selectedIndices.append(index)
         }
     }
-    
+
     func isSelected(_ index: Int) -> Bool {
         selectedIndices.contains(index)
     }
-    
+
     func selectionOrder(_ index: Int) -> Int? {
-        selectedIndices.firstIndex(of: index).map { $0 + 1 } // 1부터 보이게
+        selectedIndices.firstIndex(of: index).map { $0 + 1 }  // 1부터 보이게
 
     }
-    
+
     func tapNextButton() {
+        saveSelectedImages()
         navigationManager.navigate(to: .main(.pawcutFrameSelection))
     }
-    
+
     func tapBackButton() {
         navigationManager.pop()
     }

--- a/PawCut/PawCut/Sources/Views/PawcutFrame/PawcutFrameView.swift
+++ b/PawCut/PawCut/Sources/Views/PawcutFrame/PawcutFrameView.swift
@@ -90,6 +90,8 @@ struct PawcutFrameView: View {
                 if viewModel.selectedFrameIndex == nil {
                     viewModel.selectedFrameIndex = 0
                 }
+                
+                viewModel.loadSelectedImages()
             }
             .frame(maxHeight: .infinity, alignment: .top)
             .overlay(
@@ -102,10 +104,9 @@ struct PawcutFrameView: View {
                             confirmTitle: "홈으로 가기",
                             cancelTitle: "닫기",
                             isPresented: $viewModel.isBottomSheetPresented,
-                            // TODO: 확인
                             confirmAction: {
+                                viewModel.tapHomeButton()
                             },
-                            // TODO: 취소
                             cancelAction: {
                             }
                         )


### PR DESCRIPTION
<!--
PR을 제출하기 전에 다음 사항들을 확인해주세요:
- 제목에 PR의 내용을 명확히 설명했나요?
- 모든 코드를 로컬 환경에서 테스트해 보았나요?
- 관련 문서를 업데이트했나요?
-->

## 변경 사항 (Changes)
<!--
이 PR에서 변경된 내용을 간략하게 설명해주세요.
-->

_PawcutSelectionViewModel_
- 선택 화면(PawcutSelectionViewModel)에서 4장의 선택 이미지를 UserDefaults에 순서대로 저장할 수 있도록 saveSelectedImages() 메서드 추가


_PawcutFrameViewModel_
- 프레임 화면(PawcutFrameViewModel)에서 저장된 이미지를 불러와 그리드에 4장을 순서대로 배치하도록 loadSelectedImages() 메서드 추가
- 불필요하게 @Published가 붙어 있던 프레임 리소스 배열(frameScrollImageNames, frameImageNames)을 일반 var로 변경
- “저장 완료” 바텀시트의 확인 버튼에서 홈 화면으로 이동하도록 tapHomeButton() 동작 추가

## 변경 이유 (Reason for Changes)
<!--
이 변경 사항이 필요한 이유와 문제를 어떻게 해결하는지 설명해주세요.
-->

## 관련 이슈 (Related Issue)
<!--
이 PR이 해결하는 관련 이슈 번호를 참조하세요. 예: #123
-->

## 테스트 방법 (How to Test)
<!--
변경 사항이 적용되었는지 테스트하기 위해 수행해야 하는 단계를 설명해주세요.
1. Go to '...'
2. Click on '...'
3. Observe '...'
-->

## 추가 정보 (Additional Information)
<!--
이 PR에 대한 추가적인 정보가 있으면 제공해주세요.
-->
