### PR TITLE
[Bug] 이미지 저장 시 warning 로그 개선

### DIFF
--- a/PawCut/PawCut/Sources/Utility/Managers/ImageFile/ImageFileManager.swift
+++ b/PawCut/PawCut/Sources/Utility/Managers/ImageFile/ImageFileManager.swift
@@ -48,18 +48,38 @@ extension ImageFileManager {
         
         let fileURL = documentsDirectory.appendingPathComponent(finalFileName)
         
-        // JPEG 데이터 변환
-        guard let imageData = image.jpegData(compressionQuality: compressionQuality ) else {
+        // 알파 채널 제거 후 JPEG 변환
+        let processedImage = removeAlphaChannel(from: image)
+        
+        guard let imageData = processedImage.jpegData(compressionQuality: compressionQuality) else {
             throw ImageFileError.imageConversionFailed
         }
         
         // 파일 저장
         do {
             try imageData.write(to: fileURL)
-            cache.setObject(image, forKey: finalFileName as NSString)
+            cache.setObject(processedImage, forKey: finalFileName as NSString)
             return finalFileName
         } catch {
             throw ImageFileError.saveToSandboxFailed
+        }
+    }
+
+    // 알파 채널 제거 메서드 추가
+    private func removeAlphaChannel(from image: UIImage) -> UIImage {
+        let size = image.size
+        
+        let format = UIGraphicsImageRendererFormat()
+        format.opaque = true // 알파 채널 제거
+        format.scale = image.scale
+        
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        
+        return renderer.image { context in
+            context.cgContext.setFillColor(UIColor.white.cgColor)
+            context.cgContext.fill(CGRect(origin: .zero, size: size))
+            
+            image.draw(in: CGRect(origin: .zero, size: size))
         }
     }
     
@@ -142,7 +162,7 @@ extension ImageFileManager {
         }.sorted { url1, url2 in
             let date1 = (try? url1.resourceValues(forKeys: [.creationDateKey]))?.creationDate ?? Date.distantPast
             let date2 = (try? url2.resourceValues(forKeys: [.creationDateKey]))?.creationDate ?? Date.distantPast
-            return date1 > date2
+            return date1 < date2 //오름차순
         }
         
         return fileURLs.map { $0.lastPathComponent }

--- a/PawCut/PawCut/Sources/ViewModels/Archive/ArchiveViewModel.swift
+++ b/PawCut/PawCut/Sources/ViewModels/Archive/ArchiveViewModel.swift
@@ -43,10 +43,6 @@ final class ArchiveViewModel: ObservableObject {
         groupedPhotos.keys.sorted(by: <)
     }
     
-    init() {
-        // setupModelContext에서 로딩 처리
-    }
-    
     func setupModelContext(_ context: ModelContext) {
         self.modelContext = context
         loadPhotosFromDatabase()
@@ -130,7 +126,7 @@ extension ArchiveViewModel {
         Task {
             do {
                 let descriptor = FetchDescriptor<Photo>(
-                    sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+                    sortBy: [SortDescriptor(\.createdAt, order: .forward)]
                 )
                 let fetchedPhotos = try modelContext.fetch(descriptor)
                 

--- a/PawCut/PawCut/Sources/ViewModels/Archive/PhotoDetailsViewModel.swift
+++ b/PawCut/PawCut/Sources/ViewModels/Archive/PhotoDetailsViewModel.swift
@@ -99,7 +99,7 @@ extension PhotoDetailsViewModel {
         Task {
             do {
                 let descriptor = FetchDescriptor<Photo>(
-                    sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+                    sortBy: [SortDescriptor(\.createdAt, order: .forward)]
                 )
                 let allPhotos = try modelContext.fetch(descriptor)
                 

--- a/PawCut/PawCut/Sources/ViewModels/Archive/PhotoDetailsViewModel.swift
+++ b/PawCut/PawCut/Sources/ViewModels/Archive/PhotoDetailsViewModel.swift
@@ -52,7 +52,7 @@ final class PhotoDetailsViewModel: ObservableObject {
             do {
                 guard let image = await imageFileManager.loadImage(fileName: currentPhoto.fileName) else {
                     await MainActor.run {
-                        showToastMessage("이미지를 불러올 수 없습니다")
+                        showToastMessage("사진을 불러올 수 없어요.")
                         HapticManager.shared.triggerError()
                     }
                     return
@@ -61,13 +61,13 @@ final class PhotoDetailsViewModel: ObservableObject {
                 try await imageFileManager.saveToPhotoLibrary(image: image)
                 
                 await MainActor.run {
-                    showToastMessage("사진이 저장되었습니다")
+                    showToastMessage("저장이 완료되었어요.")
                     HapticManager.shared.triggerSaveComplete()
                 }
                 
             } catch {
                 await MainActor.run {
-                    showToastMessage("사진 저장에 실패했습니다")
+                    showToastMessage("저장이 실패되었어요.")
                     HapticManager.shared.triggerError()
                 }
             }
@@ -88,12 +88,13 @@ final class PhotoDetailsViewModel: ObservableObject {
     }
 }
 
-// TODO: SwiftData 처리
-// PhotoDetailsViewModel, ArchiveViewModel 로직이 중복되므로 추후 통일 해야함
+// TODO: SwiftData 처리를 extension 으로 해둠. 추후 처리 필요
 extension PhotoDetailsViewModel {
     
     func loadPhotosFromDatabase() {
-        guard let modelContext = modelContext else { return }
+        guard let modelContext = modelContext else {
+            return
+        }
         
         Task {
             do {
@@ -116,12 +117,14 @@ extension PhotoDetailsViewModel {
                     
                     self.groupedPhotos = newGroupedPhotos
                     self.updateCurrentPhotosAndIndex()
+                    
+                    if self.groupedPhotos.isEmpty {
+                        NavigationManager.shared.pop()
+                    }
+                    
+                    HapticManager.shared.triggerSuccess()
                 }
                 
-            } catch {
-                await MainActor.run {
-                    print("사진 로딩 실패: \(error)")
-                }
             }
         }
     }
@@ -146,21 +149,23 @@ extension PhotoDetailsViewModel {
         guard let modelContext = modelContext else { return }
         
         do {
-            // 실제 파일 삭제
+            // 1. 파일 삭제
             try await imageFileManager.deleteFile(fileName: photo.fileName)
             
-            // SwiftData 삭제
+            // SwiftData에서 삭제
             modelContext.delete(photo)
             try modelContext.save()
             
             await MainActor.run {
+                
+                self.showToastMessage("사진이 삭제되었어요.")
+                // 갱신
                 loadPhotosFromDatabase()
-                showToastMessage("사진이 삭제되었습니다.")
                 HapticManager.shared.triggerSuccess()
             }
         } catch {
             await MainActor.run {
-                showToastMessage("사진 삭제에 실패했습니다.")
+                showToastMessage("사진을 삭제할 수 없어요.")
                 HapticManager.shared.triggerError()
             }
         }

--- a/PawCut/PawCut/Sources/Views/Archive/PhotoDetailsView.swift
+++ b/PawCut/PawCut/Sources/Views/Archive/PhotoDetailsView.swift
@@ -12,10 +12,12 @@ struct PhotoDetailsView: View {
     @StateObject private var viewModel: PhotoDetailsViewModel
     @StateObject private var navigationManager = NavigationManager.shared
     
-    // 줌 상태를 추적하는 상태 변수
     @State private var isZoomedIn: Bool = false
     
-    // 전체 사진 목록
+    // 스크롤 위치 추적
+    @State private var scrollPosition: Photo.ID?
+    
+    // 전체 사진
     private var allPhotos: [Photo] {
         viewModel.sortedDates.flatMap { date in
             viewModel.groupedPhotos[date.startOfDay] ?? []
@@ -69,48 +71,46 @@ struct PhotoDetailsView: View {
     }
     
     private var imageGalleryView: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.horizontal, showsIndicators: false) {
-                LazyHStack(spacing: 0) {
-                    ForEach(allPhotos, id: \.id) { photo in
-                        ZoomableAsyncPhotoImageView(fileName: photo.fileName) { newScale in
-                            isZoomedIn = newScale > 1.0
-                        }
-                        .aspectRatio(contentMode: .fit)
-                        .sideTapNavigationGesture(onTapLeft: {
-                            if !isZoomedIn {
-                                moveToPreviousImage()
-                            }
-                        }, onTapRight: {
-                            if !isZoomedIn {
-                                moveToNextImage()
-                            }
-                        }, edgeRatio: 0.2)
-                        .containerRelativeFrame(.horizontal)
-                        .id(photo.id)
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(spacing: 0) {
+                ForEach(allPhotos, id: \.id) { photo in
+                    ZoomableAsyncPhotoImageView(fileName: photo.fileName) { newScale in
+                        isZoomedIn = newScale > 1.0
                     }
+                    .aspectRatio(contentMode: .fit)
+                    .sideTapNavigationGesture(onTapLeft: {
+                        if !isZoomedIn {
+                            moveToPreviousImage()
+                        }
+                    }, onTapRight: {
+                        if !isZoomedIn {
+                            moveToNextImage()
+                        }
+                    }, edgeRatio: 0.2)
+                    .containerRelativeFrame(.horizontal)
+                    .id(photo.id)
                 }
             }
-            .scrollTargetBehavior(.paging)
-            .scrollDisabled(isZoomedIn) // 줌인 상태에서 스크롤 비활성화
-            .onAppear {
-                DispatchQueue.main.async {
-                    if let photo = viewModel.currentPhoto,
-                       let index = allPhotos.firstIndex(where: { $0.id == photo.id }) {
-                        proxy.scrollTo(allPhotos[index].id, anchor: .center)
-                    }
-                }
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.paging)
+        .scrollPosition(id: $scrollPosition)
+        .scrollDisabled(isZoomedIn)
+        .onAppear {
+            if let currentPhoto = viewModel.currentPhoto {
+                scrollPosition = currentPhoto.id
             }
-            .onChange(of: viewModel.currentPhoto) { oldValue, newPhoto in
-                DispatchQueue.main.async {
-                    if let newPhoto = newPhoto {
-                        if oldValue == nil {
-                            proxy.scrollTo(newPhoto.id, anchor: .center)
-                        } else {
-                            withAnimation {
-                                proxy.scrollTo(newPhoto.id, anchor: .center)
-                            }
-                        }
+        }
+        .onChange(of: scrollPosition) { _, newScrollPosition in
+            updateViewModelFromScrollPosition(newScrollPosition)
+        }
+        .onChange(of: viewModel.currentPhoto) { oldValue, newPhoto in
+            if let newPhoto = newPhoto, scrollPosition != newPhoto.id {
+                if oldValue == nil {
+                    scrollPosition = newPhoto.id
+                } else {
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        scrollPosition = newPhoto.id
                     }
                 }
             }
@@ -168,6 +168,17 @@ struct PhotoDetailsView: View {
         }
     }
     
+    private func updateViewModelFromScrollPosition(_ newScrollPosition: Photo.ID?) {
+        guard let photoId = newScrollPosition,
+              let photo = allPhotos.first(where: { $0.id == photoId }) else { return }
+        
+        let newDate = photo.createdAt.startOfDay
+        let newIndex = viewModel.groupedPhotos[newDate]?.firstIndex(where: { $0.id == photoId }) ?? 0
+        
+        viewModel.currentDate = newDate
+        viewModel.currentIndex = newIndex
+    }
+    
     private func moveToPreviousImage() {
         if let currentPhoto = viewModel.currentPhoto,
            let currentAllIndex = allPhotos.firstIndex(where: { $0.id == currentPhoto.id }),
@@ -202,3 +213,4 @@ struct PhotoDetailsView: View {
 #Preview {
     PhotoDetailsView(initialDate: Date(), initialIndex: 0)
 }
+


### PR DESCRIPTION
<!--
PR을 제출하기 전에 다음 사항들을 확인해주세요:
- 제목에 PR의 내용을 명확히 설명했나요?
- 모든 코드를 로컬 환경에서 테스트해 보았나요?
- 관련 문서를 업데이트했나요?
-->

## 변경 사항 (Changes)
<!--
이 PR에서 변경된 내용을 간략하게 설명해주세요.
-->

1c1e44a  fix: 정렬 오류 수정
f850dab fix: 알파 채널 있을 시 제거 하는 로직 추가


writeImageAtIndex:1035: ⭕️ ERROR: 'PawCut' is trying to save an opaque image (855x1320) with 'AlphaPremulLast'. This would unnecessarily increase the file size and will double (!!!) the required memory when decoding the image --> ignoring alpha.

문제:

PNG나 투명도가 있는 이미지를 JPEG로 저장할 때 발생
알파 채널이 있는 이미지를 AlphaPremulLast 포맷으로 저장하려고 함
파일 크기 증가 + 메모리 사용량 2배 증가 경고


removeAlphaChannel()로 알파 채널을 제거하지 않으면
불필요한 알파 채널로 파일 크기 증가 + 메모리 2배 사용이 됩니다.



```swift
// PawCut/PawCut/Sources/Utility/Managers/ImageFile/ImageFileManager.swift
 // 알파 채널 제거 메서드 추가
    private func removeAlphaChannel(from image: UIImage) -> UIImage {
        let size = image.size
        
        let format = UIGraphicsImageRendererFormat()
        format.opaque = true // 알파 채널 제거
        format.scale = image.scale
        
        let renderer = UIGraphicsImageRenderer(size: size, format: format)
        
        return renderer.image { context in
            context.cgContext.setFillColor(UIColor.white.cgColor)
            context.cgContext.fill(CGRect(origin: .zero, size: size))
            
            image.draw(in: CGRect(origin: .zero, size: size))
        }
    }
```



+ 작업하면서 이미지 정렬 반대로 되어있길래... 수정했습니다.

## 변경 이유 (Reason for Changes)
<!--
이 변경 사항이 필요한 이유와 문제를 어떻게 해결하는지 설명해주세요.
-->

## 관련 이슈 (Related Issue)
<!--
이 PR이 해결하는 관련 이슈 번호를 참조하세요. 예: #123
-->

## 테스트 방법 (How to Test)
<!--
변경 사항이 적용되었는지 테스트하기 위해 수행해야 하는 단계를 설명해주세요.
1. Go to '...'
2. Click on '...'
3. Observe '...'
-->

## 추가 정보 (Additional Information)
<!--
이 PR에 대한 추가적인 정보가 있으면 제공해주세요.
-->
