### PR TITLE
[Fix] 사진 4장이 아니라서 다음 버튼이 비활성화 상태일 경우, 누르면 넘어가는 버그 수정

### DIFF
--- a/PawCut/PawCut/Sources/ViewModels/PawcutCamera/PawcutCameraViewModel.swift
+++ b/PawCut/PawCut/Sources/ViewModels/PawcutCamera/PawcutCameraViewModel.swift
@@ -303,9 +303,11 @@ final class PawcutCameraViewModel: NSObject, ObservableObject {
     
     private func setupCamera() {
         checkCameraPermission { [weak self] granted in
-            self?.cameraPermissionGranted = granted
-            if granted {
-                self?.configureCameraSession()
+            DispatchQueue.main.async {
+                self?.cameraPermissionGranted = granted
+                if granted {
+                    self?.configureCameraSession()
+                }
             }
         }
     }

--- a/PawCut/PawCut/Sources/ViewModels/PawcutSelect/PawcutSelectionViewModel.swift
+++ b/PawCut/PawCut/Sources/ViewModels/PawcutSelect/PawcutSelectionViewModel.swift
@@ -39,7 +39,9 @@ class PawcutSelectionViewModel: ObservableObject {
     }
 
     func tapNextButton() {
-        navigationManager.navigate(to: .main(.pawcutFrameSelection(images: selectedImagesInOrder)))
+        if selectedCount == 4 {
+            navigationManager.navigate(to: .main(.pawcutFrameSelection(images: selectedImagesInOrder)))
+        }
     }
 
     func tapBackButton() {

--- a/PawCut/PawCut/Sources/Views/PawcutSelect/PawcutSelectionView.swift
+++ b/PawCut/PawCut/Sources/Views/PawcutSelect/PawcutSelectionView.swift
@@ -46,14 +46,8 @@ struct PawcutSelectionView: View {
 
                 SelectableImageScrollView(viewModel: viewModel)
                 
-                if viewModel.selectedCount == 4 {
-                    PawPrimaryButton("다음") {
-                        viewModel.tapNextButton()
-                    }
-                } else {
-                    PawSecondaryButton("다음") {
-                        viewModel.tapNextButton()
-                    }
+                PawPrimaryButton("다음", isEnabled: viewModel.selectedCount == 4) {
+                    viewModel.tapNextButton()
                 }
             }
             .frame(maxHeight: .infinity, alignment: .top)


### PR DESCRIPTION
## 변경 사항 (Changes)
+ da778b5 fix: 4장이하일 경우 다음화면으로 넘어가는 버그 수정

## 변경 이유 (Reason for Changes)
4장 미만일 경우 넘어가면 안되기 때문입니다.

## 관련 이슈 (Related Issue)
+ closes #138 

## 추가 정보 (Additional Information)
+ 없음
