### PR TITLE
fix: 다크모드 제한

### DIFF
--- a/PawCut/PawCut/Info.plist
+++ b/PawCut/PawCut/Info.plist
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>UIAppFonts</key>
-	<array>
-		<string>Pretendard-Bold.otf</string>
-		<string>Pretendard-Medium.otf</string>
-		<string>Pretendard-SemiBold.otf</string>
-	</array>
-</dict>
+    <dict>
+        <key>UIAppFonts</key>
+        <array>
+            <string>Pretendard-Bold.otf</string>
+            <string>Pretendard-Medium.otf</string>
+            <string>Pretendard-SemiBold.otf</string>
+        </array>
+        <key>UIUserInterfaceStyle</key>
+        <string>Light</string>
+    </dict>
 </plist>


### PR DESCRIPTION
## 변경 사항 (Changes)
+ d8b308c feat: info.plist에 UIUserInterfaceStyle 프로퍼티 추가

## 변경 이유 (Reason for Changes)
다크모드를 제한합니다.

## 관련 이슈 (Related Issue)
+ closes #169 

## 테스트 방법 (How to Test)
시스템 설정으로 이동
다크모드 선택 후, 앱 진입

## 추가 정보 (Additional Information)
없음
