### PR TITLE
[Refactor] PawcutCameraView 리펙토링

### DIFF
--- a/PawCut/PawCut/Sources/Views/PawcutCamera/PawcutCameraView.swift
+++ b/PawCut/PawCut/Sources/Views/PawcutCamera/PawcutCameraView.swift
@@ -15,25 +15,17 @@ struct PawcutCameraView: View {
         ZStack {
             Color.grayScale01.ignoresSafeArea()
             
-            if let image = viewModel.rawImage {
-                Image(uiImage: image)
+            (viewModel.rawImage.map { image in
+                AnyView(Image(uiImage: image)
                     .resizable()
-                    .scaledToFill()
-                    .frame(
-                        width: UIScreen.main.bounds.width,
-                        height: UIScreen.main.bounds.width * 4 / 3
-                    )
-                    .clipped()
-                    .offset(y: -40)
-            } else {
-                Rectangle()
-                    .fill(Color.grayScale03.opacity(0.3))
-                    .frame(
-                        width: UIScreen.main.bounds.width,
-                        height: UIScreen.main.bounds.width * 4 / 3
-                    )
-                    .offset(y: -40)
-            }
+                    .scaledToFill())
+            } ?? AnyView(Rectangle().fill(Color.grayScale03.opacity(0.3))))
+            .frame(
+                width: UIScreen.main.bounds.width,
+                height: UIScreen.main.bounds.width * 4 / 3
+            )
+            .clipped()
+            .offset(y: -40)
             
             if viewModel.showShutter {
                 Color.grayScale01.opacity(1)
@@ -54,17 +46,27 @@ struct PawcutCameraView: View {
                 .clipShape(Capsule())
                 .offset(y: -270)
             
-            if let timeLeft = viewModel.countdownNumber {
-                    Text("\(timeLeft)")
-                    .font(.system(size: 100, weight: .bold))
-                    .foregroundColor(.white)
-                    .shadow(radius: 5)
-                    .transition(.opacity)
-                    .padding(.bottom, 60)
-
-            }
+            Text("\(viewModel.countdownNumber ?? 0)")
+                .font(.system(size: 100, weight: .bold))
+                .foregroundColor(.white)
+                .shadow(radius: 5)
+                .transition(.opacity)
+                .padding(.bottom, 60)
             
-            PawcutCameraBottomSubView(viewModel: viewModel)
+            PawcutCameraBottomSubView(
+                zoomOptions: viewModel.zoomOptions,
+                selectedZoomId: viewModel.selectedZoomId,
+                cameraPosition: viewModel.cameraPosition,
+                isZoomedIn: viewModel.isZoomedIn,
+                onZoomChange: { zoomId in viewModel.setZoom(zoomId) },
+                onToggleFrontZoom: { viewModel.toggleFrontZoom() },
+                onExtendCountdown: { viewModel.extendCountdown() },
+                onPerformCapture: {
+                    viewModel.cancelCountdown()
+                    viewModel.performCapture()
+                },
+                onToggleCamera: { viewModel.toggleCamera() }
+            )
             if viewModel.showSoundTooltip {
                 VStack {
                     HStack {

--- a/PawCut/PawCut/Sources/Views/PawcutCamera/PawcutCameraView.swift
+++ b/PawCut/PawCut/Sources/Views/PawcutCamera/PawcutCameraView.swift
@@ -34,6 +34,7 @@ struct PawcutCameraView: View {
                     )
                     .offset(y: -40)
             }
+            
             if viewModel.showShutter {
                 Color.grayScale01.opacity(1)
                     .ignoresSafeArea()
@@ -43,162 +44,44 @@ struct PawcutCameraView: View {
                         value: viewModel.showShutter
                     )
             }
-            ZStack {
+            
+            PawcutCameraTopSubView(viewModel: viewModel)
+            
+            PawBodyLabel.semi16("\(viewModel.currentShotIndex) / 8", color: .grayScale06)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Color.grayScale06.opacity(0.2))
+                .clipShape(Capsule())
+                .offset(y: -270)
+            
+            if let timeLeft = viewModel.countdownNumber {
+                PawTitleLabel.bold24("\(timeLeft)", color: .grayScale06)
+                    .font(.system(size: 100, weight: .bold))
+                    .shadow(radius: 5)
+                    .transition(.opacity)
+                    .padding(.bottom, 60)
+            }
+            
+            PawcutCameraBottomSubView(viewModel: viewModel)
+            if viewModel.showSoundTooltip {
                 VStack {
                     HStack {
-                        Button(action: {
-                            viewModel.tapBackButton()
-                        }) {
-                            Image(systemName: "chevron.left")
-                                .font(.system(size: 18, weight: .semibold))
-                                .foregroundColor(.grayScale06)
-                        }
-                        .frame(height: 44)
-                        .contentShape(Rectangle())
-                        
                         Spacer()
-                        
-                        Button(action: {
-                            viewModel.playSound()
-                        }) {
-                            ImageComponent(
-                                imageName: "pawcut_sound",
-                                size: CGSize(width: 22, height: 22)
-                            )
-                            .scaleEffect(viewModel.soundButtonScale)
-                            .animation(
-                                .easeInOut(duration: 1.5).repeatForever(
-                                    autoreverses: true
-                                ),
-                                value: viewModel.soundButtonScale
-                            )
-                        }
-                        
-                        Button(action: {
-                            viewModel.toggleFlash()
-                        }) {
-                            ImageComponent(
-                                imageName: viewModel.isFlashEnabled
-                                ? "flash_light" : "flash_dark",
-                                size: CGSize(width: 22, height: 22)
-                            )
-                            .opacity(viewModel.isFlashEnabled ? 1.0 : 1.0)
-                            .scaleEffect(viewModel.isFlashEnabled ? 1.1 : 1.0)
-                            .animation(
-                                .easeInOut(duration: 0.2),
-                                value: viewModel.isFlashEnabled
-                            )
-                        }
-                        .frame(width: 36, height: 42)
-                    }
-                    .padding(.horizontal, 16)
-                    .padding(.top, 0)
-                    Spacer()
-                }
-                PawBodyLabel.semi16("\(viewModel.currentShotIndex) / 8", color: .grayScale06)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(Color.grayScale06.opacity(0.2))
-                    .clipShape(Capsule())
-                    .offset(y: -270)
-                if let timeLeft = viewModel.countdownNumber {
-                    PawTitleLabel.bold24("\(timeLeft)", color: .grayScale06)
-                        .font(.system(size: 100, weight: .bold))
-                        .shadow(radius: 5)
-                        .transition(.opacity)
-                        .padding(.bottom, 60)
-                }
-                VStack {
-                    Spacer()
-                    if viewModel.cameraPosition == .back {
-                        HStack(spacing: 20) {
-                            ForEach(viewModel.zoomOptions, id: \.id) { option in
-                                let isSelected = option.id == viewModel.selectedZoomId
-                                Button(action: {
-                                    viewModel.setZoom(option.id)
-                                }) {
-                                    PawBodyLabel.semi16(option.title, color: .grayScale06)
-                                        .frame(
-                                            width: isSelected ? 36 : 24,
-                                            height: isSelected ? 36 : 24
-                                        )
-                                        .background(Color.grayScale06.opacity(0.3))
-                                        .clipShape(Circle())
-                                        .shadow(radius: 2)
-                                }
-                            }
-                        }
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(Color.grayScale06.opacity(0.1))
-                        .cornerRadius(105)
-                        .padding(.bottom, 76)
-                    } else {
-                        Button(action: {
-                            viewModel.toggleFrontZoom()
-                        }) {
-                            ImageComponent(
-                                imageName: viewModel.isZoomedIn ? "zoom_out" : "zoom_in",
-                                size: CGSize(width: 35, height: 35)
-                            )
-                            .frame(width: 35, height: 35)
-                            .background(Color.grayScale06.opacity(0.35))
-                            .clipShape(Circle())
-                        }
-                        .scaleEffect(viewModel.isZoomedIn ? 1.1 : 1.0)
-                        .animation(.easeInOut(duration: 0.2), value: viewModel.isZoomedIn)
-                        .padding(.bottom, 76)
-                    }
-                    HStack(spacing: 77) {
-                        Button(action: {
-                            viewModel.extendCountdown()
-                        }) {
-                            ImageComponent(
-                                imageName: "timer_icon",
-                                size: CGSize(width: 48, height: 48)
-                            )
-                        }
-                        
-                        Button(action: {
-                            viewModel.cancelCountdown()
-                            viewModel.performCapture()
-                        }) {
-                            ImageComponent(
-                                imageName: "camera_icon",
-                                size: CGSize(width: 68, height: 82)
-                            )
-                        }
-                        
-                        Button(action: {
-                            viewModel.toggleCamera()
-                        }) {
-                            ImageComponent(
-                                imageName: "stitch_icon",
-                                size: CGSize(width: 48, height: 48)
-                            )
-                        }
-                    }
-                }
-                .padding(.bottom, 20)
-                if viewModel.showSoundTooltip {
-                    VStack {
-                        HStack {
-                            Spacer()
-                            PawToolTip(
-                                message: "소리를 설정에서 변경할 수 있어요!"
-                            )
-                            .padding(.top, 48)
-                            .padding(.trailing, -125)
-                            Spacer()
-                        }
+                        PawToolTip(
+                            message: "소리를 설정에서 변경할 수 있어요!"
+                        )
+                        .padding(.top, 48)
+                        .padding(.trailing, -126)
                         Spacer()
                     }
-                    .transition(.opacity.combined(with: .scale))
-                    .onTapGesture {
-                        viewModel.hideSoundTooltip()
-                    }
+                    Spacer()
+                }
+                .transition(.opacity.combined(with: .scale))
+                .onTapGesture {
+                    viewModel.hideSoundTooltip()
                 }
             }
+            
         }
         .toolbar(.hidden, for: .navigationBar)
         .onChange(of: viewModel.session.isRunning) { _, isRunning in

--- a/PawCut/PawCut/Sources/Views/PawcutCamera/PawcutCameraView.swift
+++ b/PawCut/PawCut/Sources/Views/PawcutCamera/PawcutCameraView.swift
@@ -13,10 +13,205 @@ struct PawcutCameraView: View {
     
     var body: some View {
         ZStack {
-            backgroundLayer
-            cameraPreviewLayer
-            shutterAnimationLayer
-            uiOverlayLayer
+            Color.black.ignoresSafeArea()
+            
+            Group {
+                if let image = viewModel.rawImage {
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(
+                            width: UIScreen.main.bounds.width,
+                            height: UIScreen.main.bounds.width * 4 / 3
+                        )
+                        .clipped()
+                        .offset(y: -40)
+                } else {
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.3))
+                        .frame(
+                            width: UIScreen.main.bounds.width,
+                            height: UIScreen.main.bounds.width * 4 / 3
+                        )
+                        .offset(y: -40)
+                }
+            }
+            Group {
+                if viewModel.showShutter {
+                    Color.black.opacity(1)
+                        .ignoresSafeArea()
+                        .transition(.opacity)
+                        .animation(
+                            .easeOut(duration: 0.05),
+                            value: viewModel.showShutter
+                        )
+                }
+            }
+            ZStack {
+                VStack {
+                    HStack {
+                        Button(action: {
+                            viewModel.tapBackButton()
+                        }) {
+                            Image(systemName: "chevron.left")
+                                .font(.system(size: 18, weight: .semibold))
+                                .foregroundColor(.white)
+                        }
+                        .frame(height: 44)
+                        .contentShape(Rectangle())
+                        
+                        Spacer()
+                        
+                        Button(action: {
+                            viewModel.playSound()
+                        }) {
+                            ImageComponent(
+                                imageName: "pawcut_sound",
+                                size: CGSize(width: 22, height: 22)
+                            )
+                            .scaleEffect(viewModel.soundButtonScale)
+                            .animation(
+                                .easeInOut(duration: 1.5).repeatForever(
+                                    autoreverses: true
+                                ),
+                                value: viewModel.soundButtonScale
+                            )
+                        }
+                        
+                        Button(action: {
+                            viewModel.toggleFlash()
+                        }) {
+                            ImageComponent(
+                                imageName: viewModel.isFlashEnabled
+                                ? "flash_light" : "flash_dark",
+                                size: CGSize(width: 22, height: 22)
+                            )
+                            .opacity(viewModel.isFlashEnabled ? 1.0 : 1.0)
+                            .scaleEffect(viewModel.isFlashEnabled ? 1.1 : 1.0)
+                            .animation(
+                                .easeInOut(duration: 0.2),
+                                value: viewModel.isFlashEnabled
+                            )
+                        }
+                        .frame(width: 36, height: 42)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 0)
+                    Spacer()
+                }
+                Text("\(viewModel.currentShotIndex) / 8")
+                    .pretendardFont(size: ._16, weight: .semibold)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Color.white.opacity(0.2))
+                    .foregroundColor(.white)
+                    .clipShape(Capsule())
+                    .offset(y: -270)
+                Group {
+                    if let timeLeft = viewModel.countdownNumber {
+                        Text("\(timeLeft)")
+                            .font(.system(size: 100, weight: .bold))
+                            .foregroundColor(.white)
+                            .shadow(radius: 5)
+                            .transition(.opacity)
+                            .padding(.bottom, 60)
+                    }
+                }
+                VStack {
+                    Spacer()
+                    if viewModel.cameraPosition == .back {
+                        HStack(spacing: 20) {
+                            ForEach(viewModel.zoomOptions, id: \.id) { option in
+                                let isSelected = option.id == viewModel.selectedZoomId
+                                Button(action: {
+                                    viewModel.setZoom(option.id)
+                                }) {
+                                    Text(option.title)
+                                        .pretendardFont(size: ._14, weight: .semibold)
+                                        .foregroundColor(Color.white)
+                                        .frame(
+                                            width: isSelected ? 36 : 24,
+                                            height: isSelected ? 36 : 24
+                                        )
+                                        .background(Color.white.opacity(0.3))
+                                        .clipShape(Circle())
+                                        .shadow(radius: 2)
+                                }
+                            }
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.white.opacity(0.1))
+                        .cornerRadius(105)
+                        .padding(.bottom, 76)
+                    } else {
+                        Button(action: {
+                            viewModel.toggleFrontZoom()
+                        }) {
+                            ImageComponent(
+                                imageName: viewModel.isZoomedIn ? "zoom_out" : "zoom_in",
+                                size: CGSize(width: 35, height: 35)
+                            )
+                            .frame(width: 35, height: 35)
+                            .background(Color.white.opacity(0.35))
+                            .clipShape(Circle())
+                        }
+                        .scaleEffect(viewModel.isZoomedIn ? 1.1 : 1.0)
+                        .animation(.easeInOut(duration: 0.2), value: viewModel.isZoomedIn)
+                        .padding(.bottom, 76)
+                    }
+                    HStack(spacing: 77) {
+                        Button(action: {
+                            viewModel.extendCountdown()
+                        }) {
+                            ImageComponent(
+                                imageName: "timer_icon",
+                                size: CGSize(width: 48, height: 48)
+                            )
+                        }
+                        
+                        Button(action: {
+                            viewModel.cancelCountdown()
+                            viewModel.performCapture()
+                        }) {
+                            ImageComponent(
+                                imageName: "camera_icon",
+                                size: CGSize(width: 68, height: 82)
+                            )
+                        }
+                        
+                        Button(action: {
+                            viewModel.toggleCamera()
+                        }) {
+                            ImageComponent(
+                                imageName: "stitch_icon",
+                                size: CGSize(width: 48, height: 48)
+                            )
+                        }
+                    }
+                }
+                .padding(.bottom, 20)
+                Group {
+                    if viewModel.showSoundTooltip {
+                        VStack {
+                            HStack {
+                                Spacer()
+                                PawToolTip(
+                                    message: "소리를 설정에서 변경할 수 있어요!"
+                                )
+                                .padding(.top, 48)
+                                .padding(.trailing, -125)
+                                Spacer()
+                            }
+                            Spacer()
+                        }
+                        .transition(.opacity.combined(with: .scale))
+                        .onTapGesture {
+                            viewModel.hideSoundTooltip()
+                        }
+                    }
+                }
+            }
         }
         .toolbar(.hidden, for: .navigationBar)
         .onChange(of: viewModel.session.isRunning) { _, isRunning in
@@ -33,251 +228,6 @@ struct PawcutCameraView: View {
             )
         ) { _ in
             viewModel.pauseCountdown()
-        }
-    }
-    
-    // TODO: 변수로 분리한 친구들 다시 원상 복귀 후, 뷰로 분리
-    
-    private var backgroundLayer: some View {
-        Color.black.ignoresSafeArea()
-    }
-    
-    private var cameraPreviewLayer: some View {
-        Group {
-            if let image = viewModel.rawImage {
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(
-                        width: UIScreen.main.bounds.width,
-                        height: UIScreen.main.bounds.width * 4 / 3
-                    )
-                    .clipped()
-                    .offset(y: -40)
-            } else {
-                Rectangle()
-                    .fill(Color.gray.opacity(0.3))
-                    .frame(
-                        width: UIScreen.main.bounds.width,
-                        height: UIScreen.main.bounds.width * 4 / 3
-                    )
-                    .offset(y: -40)
-            }
-        }
-    }
-    
-    private var shutterAnimationLayer: some View {
-        Group {
-            if viewModel.showShutter {
-                Color.black.opacity(1)
-                    .ignoresSafeArea()
-                    .transition(.opacity)
-                    .animation(
-                        .easeOut(duration: 0.05),
-                        value: viewModel.showShutter
-                    )
-            }
-        }
-    }
-
-    private var uiOverlayLayer: some View {
-        ZStack {
-            topNavigationView
-            shotProgressView
-            countdownView
-            bottomControlsView
-            tooltipView
-        }
-    }
-    
-    
-    private var topNavigationView: some View {
-        VStack {
-            HStack {
-                Button(action: {
-                    viewModel.tapBackButton()
-                }) {
-                    Image(systemName: "chevron.left")
-                        .font(.system(size: 18, weight: .semibold))
-                        .foregroundColor(.white)
-                }
-                .frame(height: 44)
-                .contentShape(Rectangle())
-                
-                Spacer()
-                
-                Button(action: {
-                    viewModel.playSound()
-                }) {
-                    ImageComponent(
-                        imageName: "pawcut_sound",
-                        size: CGSize(width: 22, height: 22)
-                    )
-                    .scaleEffect(viewModel.soundButtonScale)
-                    .animation(
-                        .easeInOut(duration: 1.5).repeatForever(
-                            autoreverses: true
-                        ),
-                        value: viewModel.soundButtonScale
-                    )
-                }
-                
-                Button(action: {
-                    viewModel.toggleFlash()
-                }) {
-                    ImageComponent(
-                        imageName: viewModel.isFlashEnabled
-                        ? "flash_light" : "flash_dark",
-                        size: CGSize(width: 22, height: 22)
-                    )
-                    .opacity(viewModel.isFlashEnabled ? 1.0 : 1.0)
-                    .scaleEffect(viewModel.isFlashEnabled ? 1.1 : 1.0)
-                    .animation(
-                        .easeInOut(duration: 0.2),
-                        value: viewModel.isFlashEnabled
-                    )
-                }
-                .frame(width: 36, height: 42)
-            }
-            .padding(.horizontal, 16)
-            .padding(.top, 0)
-            Spacer()
-        }
-    }
-    
-    private var shotProgressView: some View {
-        Text("\(viewModel.currentShotIndex) / 8")
-            .pretendardFont(size: ._16, weight: .semibold)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(Color.white.opacity(0.2))
-            .foregroundColor(.white)
-            .clipShape(Capsule())
-            .offset(y: -270)
-    }
-    
-    private var countdownView: some View {
-        Group {
-            if let timeLeft = viewModel.countdownNumber {
-                Text("\(timeLeft)")
-                    .font(.system(size: 100, weight: .bold))
-                    .foregroundColor(.white)
-                    .shadow(radius: 5)
-                    .transition(.opacity)
-                    .padding(.bottom, 60)
-            }
-        }
-    }
-    
-    private var bottomControlsView: some View {
-        VStack {
-            Spacer()
-            if viewModel.cameraPosition == .back {
-                zoomControlView
-                    .padding(.bottom, 76)
-            } else {
-                frontZoomControlView
-                    .padding(.bottom, 76)
-            }
-            bottomButtonsView
-        }
-        .padding(.bottom, 20)
-    }
-    
-    private var zoomControlView: some View {
-        HStack(spacing: 20) {
-            ForEach(viewModel.zoomOptions, id: \.id) { option in
-                let isSelected = option.id == viewModel.selectedZoomId
-                Button(action: {
-                    viewModel.setZoom(option.id)
-                }) {
-                    Text(option.title)
-                        .pretendardFont(size: ._14, weight: .semibold)
-                        .foregroundColor(Color.white)
-                        .frame(
-                            width: isSelected ? 36 : 24,
-                            height: isSelected ? 36 : 24
-                        )
-                        .background(Color.white.opacity(0.3))
-                        .clipShape(Circle())
-                        .shadow(radius: 2)
-                }
-            }
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(Color.white.opacity(0.1))
-        .cornerRadius(105)
-    }
-    
-    private var frontZoomControlView: some View {
-        Button(action: {
-            viewModel.toggleFrontZoom()
-        }) {
-            ImageComponent(
-                imageName: viewModel.isZoomedIn ? "zoom_out" : "zoom_in",
-                size: CGSize(width: 35, height: 35)
-            )
-            .frame(width: 35, height: 35)
-            .background(Color.white.opacity(0.35))
-            .clipShape(Circle())
-        }
-        .scaleEffect(viewModel.isZoomedIn ? 1.1 : 1.0)
-        .animation(.easeInOut(duration: 0.2), value: viewModel.isZoomedIn)
-    }
-    
-    private var bottomButtonsView: some View {
-        HStack(spacing: 77) {
-            Button(action: {
-                viewModel.extendCountdown()
-            }) {
-                ImageComponent(
-                    imageName: "timer_icon",
-                    size: CGSize(width: 48, height: 48)
-                )
-            }
-            
-            Button(action: {
-                viewModel.cancelCountdown()
-                viewModel.performCapture()
-            }) {
-                ImageComponent(
-                    imageName: "camera_icon",
-                    size: CGSize(width: 68, height: 82)
-                )
-            }
-            
-            Button(action: {
-                viewModel.toggleCamera()
-            }) {
-                ImageComponent(
-                    imageName: "stitch_icon",
-                    size: CGSize(width: 48, height: 48)
-                )
-            }
-        }
-    }
-    
-    private var tooltipView: some View {
-        Group {
-            if viewModel.showSoundTooltip {
-                VStack {
-                    HStack {
-                        Spacer()
-                            PawToolTip(
-                                message: "소리를 설정에서 변경할 수 있어요!"
-                            )
-                        .padding(.top, 48)
-                        .padding(.trailing, -125)
-                        Spacer()
-                    }
-                    Spacer()
-                }
-                .transition(.opacity.combined(with: .scale))
-                .onTapGesture {
-                    viewModel.hideSoundTooltip()
-                }
-            }
         }
     }
 }

--- a/PawCut/PawCut/Sources/Views/PawcutCamera/PawcutCameraView.swift
+++ b/PawCut/PawCut/Sources/Views/PawcutCamera/PawcutCameraView.swift
@@ -55,11 +55,13 @@ struct PawcutCameraView: View {
                 .offset(y: -270)
             
             if let timeLeft = viewModel.countdownNumber {
-                PawTitleLabel.bold24("\(timeLeft)", color: .grayScale06)
+                    Text("\(timeLeft)")
                     .font(.system(size: 100, weight: .bold))
+                    .foregroundColor(.white)
                     .shadow(radius: 5)
                     .transition(.opacity)
                     .padding(.bottom, 60)
+
             }
             
             PawcutCameraBottomSubView(viewModel: viewModel)

--- a/PawCut/PawCut/Sources/Views/PawcutCamera/PawcutCameraView.swift
+++ b/PawCut/PawCut/Sources/Views/PawcutCamera/PawcutCameraView.swift
@@ -13,39 +13,35 @@ struct PawcutCameraView: View {
     
     var body: some View {
         ZStack {
-            Color.black.ignoresSafeArea()
+            Color.grayScale01.ignoresSafeArea()
             
-            Group {
-                if let image = viewModel.rawImage {
-                    Image(uiImage: image)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(
-                            width: UIScreen.main.bounds.width,
-                            height: UIScreen.main.bounds.width * 4 / 3
-                        )
-                        .clipped()
-                        .offset(y: -40)
-                } else {
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.3))
-                        .frame(
-                            width: UIScreen.main.bounds.width,
-                            height: UIScreen.main.bounds.width * 4 / 3
-                        )
-                        .offset(y: -40)
-                }
+            if let image = viewModel.rawImage {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(
+                        width: UIScreen.main.bounds.width,
+                        height: UIScreen.main.bounds.width * 4 / 3
+                    )
+                    .clipped()
+                    .offset(y: -40)
+            } else {
+                Rectangle()
+                    .fill(Color.grayScale03.opacity(0.3))
+                    .frame(
+                        width: UIScreen.main.bounds.width,
+                        height: UIScreen.main.bounds.width * 4 / 3
+                    )
+                    .offset(y: -40)
             }
-            Group {
-                if viewModel.showShutter {
-                    Color.black.opacity(1)
-                        .ignoresSafeArea()
-                        .transition(.opacity)
-                        .animation(
-                            .easeOut(duration: 0.05),
-                            value: viewModel.showShutter
-                        )
-                }
+            if viewModel.showShutter {
+                Color.grayScale01.opacity(1)
+                    .ignoresSafeArea()
+                    .transition(.opacity)
+                    .animation(
+                        .easeOut(duration: 0.05),
+                        value: viewModel.showShutter
+                    )
             }
             ZStack {
                 VStack {
@@ -55,7 +51,7 @@ struct PawcutCameraView: View {
                         }) {
                             Image(systemName: "chevron.left")
                                 .font(.system(size: 18, weight: .semibold))
-                                .foregroundColor(.white)
+                                .foregroundColor(.grayScale06)
                         }
                         .frame(height: 44)
                         .contentShape(Rectangle())
@@ -99,23 +95,18 @@ struct PawcutCameraView: View {
                     .padding(.top, 0)
                     Spacer()
                 }
-                Text("\(viewModel.currentShotIndex) / 8")
-                    .pretendardFont(size: ._16, weight: .semibold)
+                PawBodyLabel.semi16("\(viewModel.currentShotIndex) / 8", color: .grayScale06)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
-                    .background(Color.white.opacity(0.2))
-                    .foregroundColor(.white)
+                    .background(Color.grayScale06.opacity(0.2))
                     .clipShape(Capsule())
                     .offset(y: -270)
-                Group {
-                    if let timeLeft = viewModel.countdownNumber {
-                        Text("\(timeLeft)")
-                            .font(.system(size: 100, weight: .bold))
-                            .foregroundColor(.white)
-                            .shadow(radius: 5)
-                            .transition(.opacity)
-                            .padding(.bottom, 60)
-                    }
+                if let timeLeft = viewModel.countdownNumber {
+                    PawTitleLabel.bold24("\(timeLeft)", color: .grayScale06)
+                        .font(.system(size: 100, weight: .bold))
+                        .shadow(radius: 5)
+                        .transition(.opacity)
+                        .padding(.bottom, 60)
                 }
                 VStack {
                     Spacer()
@@ -126,14 +117,12 @@ struct PawcutCameraView: View {
                                 Button(action: {
                                     viewModel.setZoom(option.id)
                                 }) {
-                                    Text(option.title)
-                                        .pretendardFont(size: ._14, weight: .semibold)
-                                        .foregroundColor(Color.white)
+                                    PawBodyLabel.semi16(option.title, color: .grayScale06)
                                         .frame(
                                             width: isSelected ? 36 : 24,
                                             height: isSelected ? 36 : 24
                                         )
-                                        .background(Color.white.opacity(0.3))
+                                        .background(Color.grayScale06.opacity(0.3))
                                         .clipShape(Circle())
                                         .shadow(radius: 2)
                                 }
@@ -141,7 +130,7 @@ struct PawcutCameraView: View {
                         }
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
-                        .background(Color.white.opacity(0.1))
+                        .background(Color.grayScale06.opacity(0.1))
                         .cornerRadius(105)
                         .padding(.bottom, 76)
                     } else {
@@ -153,7 +142,7 @@ struct PawcutCameraView: View {
                                 size: CGSize(width: 35, height: 35)
                             )
                             .frame(width: 35, height: 35)
-                            .background(Color.white.opacity(0.35))
+                            .background(Color.grayScale06.opacity(0.35))
                             .clipShape(Circle())
                         }
                         .scaleEffect(viewModel.isZoomedIn ? 1.1 : 1.0)
@@ -191,24 +180,22 @@ struct PawcutCameraView: View {
                     }
                 }
                 .padding(.bottom, 20)
-                Group {
-                    if viewModel.showSoundTooltip {
-                        VStack {
-                            HStack {
-                                Spacer()
-                                PawToolTip(
-                                    message: "소리를 설정에서 변경할 수 있어요!"
-                                )
-                                .padding(.top, 48)
-                                .padding(.trailing, -125)
-                                Spacer()
-                            }
+                if viewModel.showSoundTooltip {
+                    VStack {
+                        HStack {
+                            Spacer()
+                            PawToolTip(
+                                message: "소리를 설정에서 변경할 수 있어요!"
+                            )
+                            .padding(.top, 48)
+                            .padding(.trailing, -125)
                             Spacer()
                         }
-                        .transition(.opacity.combined(with: .scale))
-                        .onTapGesture {
-                            viewModel.hideSoundTooltip()
-                        }
+                        Spacer()
+                    }
+                    .transition(.opacity.combined(with: .scale))
+                    .onTapGesture {
+                        viewModel.hideSoundTooltip()
                     }
                 }
             }

--- a/PawCut/PawCut/Sources/Views/PawcutCamera/SubViews/PawcutCameraBottomSubView.swift
+++ b/PawCut/PawCut/Sources/Views/PawcutCamera/SubViews/PawcutCameraBottomSubView.swift
@@ -8,17 +8,27 @@
 import SwiftUI
 
 struct PawcutCameraBottomSubView: View {
-    @ObservedObject var viewModel: PawcutCameraViewModel
+
+    let zoomOptions: [PawcutCameraViewModel.ZoomOption]
+    let selectedZoomId: String
+    let cameraPosition: PawcutCameraViewModel.CameraPosition
+    let isZoomedIn: Bool
+
+    let onZoomChange: (String) -> Void
+    let onToggleFrontZoom: () -> Void
+    let onExtendCountdown: () -> Void
+    let onPerformCapture: () -> Void
+    let onToggleCamera: () -> Void
     
     var body: some View {
         VStack {
             Spacer()
-            if viewModel.cameraPosition == .back {
+            if cameraPosition == .back {
                 HStack(spacing: 20) {
-                    ForEach(viewModel.zoomOptions, id: \.id) { option in
-                        let isSelected = option.id == viewModel.selectedZoomId
+                    ForEach(zoomOptions, id: \.id) { option in
+                        let isSelected = option.id == selectedZoomId
                         Button(action: {
-                            viewModel.setZoom(option.id)
+                            onZoomChange(option.id)
                         }) {
                             PawBodyLabel.semi16(option.title, color: .grayScale06)
                                 .frame(
@@ -38,23 +48,23 @@ struct PawcutCameraBottomSubView: View {
                 .padding(.bottom, 76)
             } else {
                 Button(action: {
-                    viewModel.toggleFrontZoom()
+                    onToggleFrontZoom()
                 }) {
                     ImageComponent(
-                        imageName: viewModel.isZoomedIn ? "zoom_out" : "zoom_in",
+                        imageName: isZoomedIn ? "zoom_out" : "zoom_in",
                         size: CGSize(width: 35, height: 35)
                     )
                     .frame(width: 35, height: 35)
                     .background(Color.grayScale06.opacity(0.35))
                     .clipShape(Circle())
                 }
-                .scaleEffect(viewModel.isZoomedIn ? 1.1 : 1.0)
-                .animation(.easeInOut(duration: 0.2), value: viewModel.isZoomedIn)
+                .scaleEffect(isZoomedIn ? 1.1 : 1.0)
+                .animation(.easeInOut(duration: 0.2), value: isZoomedIn)
                 .padding(.bottom, 76)
             }
             HStack(spacing: 77) {
                 Button(action: {
-                    viewModel.extendCountdown()
+                    onExtendCountdown()
                 }) {
                     ImageComponent(
                         imageName: "timer_icon",
@@ -63,8 +73,7 @@ struct PawcutCameraBottomSubView: View {
                 }
                 
                 Button(action: {
-                    viewModel.cancelCountdown()
-                    viewModel.performCapture()
+                    onPerformCapture()
                 }) {
                     ImageComponent(
                         imageName: "camera_icon",
@@ -73,7 +82,7 @@ struct PawcutCameraBottomSubView: View {
                 }
                 
                 Button(action: {
-                    viewModel.toggleCamera()
+                    onToggleCamera()
                 }) {
                     ImageComponent(
                         imageName: "stitch_icon",
@@ -87,5 +96,19 @@ struct PawcutCameraBottomSubView: View {
 }
 
 #Preview {
-    PawcutCameraBottomSubView(viewModel: PawcutCameraViewModel())
+    PawcutCameraBottomSubView(
+        zoomOptions: [
+            PawcutCameraViewModel.ZoomOption(id: "0.5", title: ".5"),
+            PawcutCameraViewModel.ZoomOption(id: "1.0", title: "1x"),
+            PawcutCameraViewModel.ZoomOption(id: "2.0", title: "2")
+        ],
+        selectedZoomId: "1.0",
+        cameraPosition: .back,
+        isZoomedIn: false,
+        onZoomChange: { _ in },
+        onToggleFrontZoom: { },
+        onExtendCountdown: { },
+        onPerformCapture: { },
+        onToggleCamera: { }
+    )
 }

--- a/PawCut/PawCut/Sources/Views/PawcutCamera/SubViews/PawcutCameraBottomSubView.swift
+++ b/PawCut/PawCut/Sources/Views/PawcutCamera/SubViews/PawcutCameraBottomSubView.swift
@@ -1,0 +1,91 @@
+//
+//  PawcutCameraBottomSubView.swift
+//  PawCut
+//
+//  Created by 광로 on 9/24/25.
+//
+
+import SwiftUI
+
+struct PawcutCameraBottomSubView: View {
+    @ObservedObject var viewModel: PawcutCameraViewModel
+    
+    var body: some View {
+        VStack {
+            Spacer()
+            if viewModel.cameraPosition == .back {
+                HStack(spacing: 20) {
+                    ForEach(viewModel.zoomOptions, id: \.id) { option in
+                        let isSelected = option.id == viewModel.selectedZoomId
+                        Button(action: {
+                            viewModel.setZoom(option.id)
+                        }) {
+                            PawBodyLabel.semi16(option.title, color: .grayScale06)
+                                .frame(
+                                    width: isSelected ? 36 : 24,
+                                    height: isSelected ? 36 : 24
+                                )
+                                .background(Color.grayScale06.opacity(0.3))
+                                .clipShape(Circle())
+                                .shadow(radius: 2)
+                        }
+                    }
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.grayScale06.opacity(0.1))
+                .cornerRadius(105)
+                .padding(.bottom, 76)
+            } else {
+                Button(action: {
+                    viewModel.toggleFrontZoom()
+                }) {
+                    ImageComponent(
+                        imageName: viewModel.isZoomedIn ? "zoom_out" : "zoom_in",
+                        size: CGSize(width: 35, height: 35)
+                    )
+                    .frame(width: 35, height: 35)
+                    .background(Color.grayScale06.opacity(0.35))
+                    .clipShape(Circle())
+                }
+                .scaleEffect(viewModel.isZoomedIn ? 1.1 : 1.0)
+                .animation(.easeInOut(duration: 0.2), value: viewModel.isZoomedIn)
+                .padding(.bottom, 76)
+            }
+            HStack(spacing: 77) {
+                Button(action: {
+                    viewModel.extendCountdown()
+                }) {
+                    ImageComponent(
+                        imageName: "timer_icon",
+                        size: CGSize(width: 48, height: 48)
+                    )
+                }
+                
+                Button(action: {
+                    viewModel.cancelCountdown()
+                    viewModel.performCapture()
+                }) {
+                    ImageComponent(
+                        imageName: "camera_icon",
+                        size: CGSize(width: 68, height: 82)
+                    )
+                }
+                
+                Button(action: {
+                    viewModel.toggleCamera()
+                }) {
+                    ImageComponent(
+                        imageName: "stitch_icon",
+                        size: CGSize(width: 48, height: 48)
+                    )
+                }
+            }
+        }
+        .padding(.bottom, 20)
+    }
+}
+
+#Preview {
+    PawcutCameraBottomSubView(viewModel: PawcutCameraViewModel())
+}

--- a/PawCut/PawCut/Sources/Views/PawcutCamera/SubViews/PawcutCameraTopSubView.swift
+++ b/PawCut/PawCut/Sources/Views/PawcutCamera/SubViews/PawcutCameraTopSubView.swift
@@ -1,0 +1,70 @@
+//
+//  PawcutCameraTopSubView.swift
+//  PawCut
+//
+//  Created by 광로 on 9/24/25.
+//
+
+import SwiftUI
+
+struct PawcutCameraTopSubView: View {
+    @ObservedObject var viewModel: PawcutCameraViewModel
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Button(action: {
+                    viewModel.tapBackButton()
+                }) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundColor(.grayScale06)
+                }
+                .frame(height: 44)
+                .contentShape(Rectangle())
+                
+                Spacer()
+                
+                Button(action: {
+                    viewModel.playSound()
+                }) {
+                    ImageComponent(
+                        imageName: "pawcut_sound",
+                        size: CGSize(width: 22, height: 22)
+                    )
+                    .scaleEffect(viewModel.soundButtonScale)
+                    .animation(
+                        .easeInOut(duration: 1.5).repeatForever(
+                            autoreverses: true
+                        ),
+                        value: viewModel.soundButtonScale
+                    )
+                }
+                
+                Button(action: {
+                    viewModel.toggleFlash()
+                }) {
+                    ImageComponent(
+                        imageName: viewModel.isFlashEnabled
+                        ? "flash_light" : "flash_dark",
+                        size: CGSize(width: 22, height: 22)
+                    )
+                    .opacity(viewModel.isFlashEnabled ? 1.0 : 1.0)
+                    .scaleEffect(viewModel.isFlashEnabled ? 1.1 : 1.0)
+                    .animation(
+                        .easeInOut(duration: 0.2),
+                        value: viewModel.isFlashEnabled
+                    )
+                }
+                .frame(width: 36, height: 42)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 0)
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    PawcutCameraTopSubView(viewModel: PawcutCameraViewModel())
+}


### PR DESCRIPTION
## 변경 사항 (Changes)

- PawcutCameraView 변수로 불러오는 부분을 Pawcut 스타일 가이드 맞게 변경 했습니다.


<img width="344" height="163" alt="image" src="https://github.com/user-attachments/assets/3c04dfbb-43cc-4e78-9f22-4db42eceba9c" />

- 위 이미지 처럼  1) PawcutCameraBottomView  2) PawcutCameraTopView 를 추가하여 가독성을 높였습니다.

```
var body: some View {
        ZStack {
            backgroundLayer
            cameraPreviewLayer
            shutterAnimationLayer
            uiOverlayLayer
        }
        private var uiOverlayLayer: some View {
        ZStack {
            topNavigationView
            shotProgressView
            countdownView
            bottomControlsView
            tooltipView
        }
    }
```

위 코드 처럼 변수로 불러 오는 부분을 ZTackt 안에 정리했고,
VStack 부분을 위 이미지와 같이 SubView로 옮겨서 리펙토링 했습니다.


## 변경 이유 (Reason for Changes)
## 관련 이슈 (Related Issue)
closed #180 

## 테스트 방법 (How to Test)

## 추가 정보 (Additional Information)
```
 if let timeLeft = viewModel.countdownNumber {
                    Text("\(timeLeft)")
                    .font(.system(size: 100, weight: .bold))
                    .foregroundColor(.white)
                    .shadow(radius: 5)
                    .transition(.opacity)
                    .padding(.bottom, 60)
            }
```

위의 57~65 번줄은 컴포넌트화 되어 있지 않아서, 기존 코드를 유지 했습니다.