### PR TITLE
[Refactor] 이미지 줌 삐걱거리는 문제 수정 및 해결

### DIFF
--- a/PawCut/PawCut/Sources/DesignSystem/Component/Image/ZoomableAsyncPhotoImageView.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Image/ZoomableAsyncPhotoImageView.swift
@@ -9,75 +9,148 @@ import SwiftUI
 
 struct ZoomableAsyncPhotoImageView: View {
     let fileName: String
-    var onScaleChanged: (CGFloat) -> Void // 스케일 변경을 외부에 알리는 클로저
+    let onScaleChanged: (CGFloat) -> Void
     
     @State private var image: UIImage?
-    @State private var scale: CGFloat = 1.0
-    @State private var lastScale: CGFloat = 1.0
-    @State private var isZoomed: Bool = false
+    @State private var currentScale: CGFloat = 1.0
+    @State private var baseScale: CGFloat = 1.0
+    @State private var currentOffset: CGSize = .zero
+    @State private var baseOffset: CGSize = .zero
     
+    private let minScale: CGFloat = 1.0
     private let maxScale: CGFloat = 4.0
     
-    // 애셋 이미지 로딩 초기화
-    init(assetName: String, onScaleChanged: @escaping (CGFloat) -> Void) {
-        self.fileName = assetName
-        self.onScaleChanged = onScaleChanged
-    }
-    
-    // 파일 이미지 로딩 초기화
     init(fileName: String, onScaleChanged: @escaping (CGFloat) -> Void) {
         self.fileName = fileName
         self.onScaleChanged = onScaleChanged
     }
     
     var body: some View {
-        if let image = image {
-            Image(uiImage: image)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .scaleEffect(scale)
-                .onTapGesture(count: 2) {
-                    withAnimation(.spring()) {
-                        if scale > 1.0 {
-                            scale = 1.0
-                        } else {
-                            scale = 2.5 // 더블 탭 시 줌 인
-                        }
+        GeometryReader { geometry in
+            if let image = image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: geometry.size.width)
+                    .scaleEffect(currentScale)
+                    .offset(limitedOffset(for: geometry, image: image))
+                    .gesture(makeZoomAndPanGesture(for: geometry, image: image))
+                    .onTapGesture(count: 2) {
+                        handleDoubleTap()
+                    }
+            } else {
+                Image("empty_image")
+                    .frame(maxWidth: .infinity)
+                    .background(Color.grayScale06)
+                    .onAppear {
+                        loadImage()
+                    }
+            }
+        }
+        .onChange(of: currentScale) { _, newScale in
+            onScaleChanged(newScale)
+        }
+    }
+    
+    private func makeZoomAndPanGesture(for geometry: GeometryProxy, image: UIImage) -> some Gesture {
+        SimultaneousGesture(
+            magnificationGesture(),
+            dragGesture(for: geometry, image: image)
+        )
+    }
+    
+    // pinch zoom
+    private func magnificationGesture() -> some Gesture {
+        MagnificationGesture()
+            .onChanged { value in
+                let newScale = baseScale * value
+                currentScale = min(max(newScale, minScale), maxScale)
+            }
+            .onEnded { _ in
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                    if currentScale < minScale {
+                        currentScale = minScale
+                        currentOffset = .zero
+                        baseOffset = .zero
+                    } else if currentScale > maxScale {
+                        currentScale = maxScale
                     }
                 }
-                .gesture(
-                    MagnificationGesture()
-                        .onChanged { value in
-                            let delta = value / lastScale
-                            lastScale = value
-                            scale *= delta
-                        }
-                        .onEnded { _ in
-                            lastScale = 1.0
-                            withAnimation(.spring()) {
-                                scale = max(1.0, min(scale, maxScale))
-                            }
-                        }
+                baseScale = currentScale
+            }
+    }
+    
+    // pan gesture
+    private func dragGesture(for geometry: GeometryProxy, image: UIImage) -> some Gesture {
+        DragGesture()
+            .onChanged { value in
+                guard currentScale > 1.0 else { return }
+                
+                let newOffset = CGSize(
+                    width: baseOffset.width + value.translation.width,
+                    height: baseOffset.height + value.translation.height
                 )
-                .onChange(of: scale) { _, newScale in
-                    withAnimation(.spring()) {
-                        isZoomed = newScale > 1.0
-                        onScaleChanged(newScale)
-                    }
-                }
+                currentOffset = newOffset
+            }
+            .onEnded { _ in
+                baseOffset = currentOffset
+            }
+    }
+    
+    // double tap
+    private func handleDoubleTap() {
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+            if currentScale > 1.0 {
+                currentScale = 1.0
+                currentOffset = .zero
+                baseOffset = .zero
+            } else {
+                currentScale = 2.5
+            }
+        }
+        baseScale = currentScale
+    }
+    
+    // device limited
+    private func limitedOffset(for geometry: GeometryProxy, image: UIImage) -> CGSize {
+        guard currentScale > 1.0 else {
+            return .zero
+        }
+        
+        let imageSize = calculateImageSize(for: geometry, image: image)
+        let scaledWidth = imageSize.width * currentScale
+        let scaledHeight = imageSize.height * currentScale
+        
+        let maxOffsetX = max(0, (scaledWidth - geometry.size.width) / 2)
+        let maxOffsetY = max(0, (scaledHeight - geometry.size.height) / 2)
+        
+        let limitedX = min(max(currentOffset.width, -maxOffsetX), maxOffsetX)
+        let limitedY = min(max(currentOffset.height, -maxOffsetY), maxOffsetY)
+        
+        return CGSize(width: limitedX, height: limitedY)
+    }
+    
+    // 실제 표시되는 이미지 크기 계산
+    private func calculateImageSize(for geometry: GeometryProxy, image: UIImage) -> CGSize {
+        let imageRatio = image.size.width / image.size.height
+        let viewRatio = geometry.size.width / geometry.size.height
+        
+        if imageRatio > viewRatio {
+            let width = geometry.size.width
+            let height = width / imageRatio
+            return CGSize(width: width, height: height)
         } else {
-            Image("empty_image")
-                .frame(maxWidth: .infinity)
-                .background(Color.grayScale06)
-                .onAppear {
-                    loadImage()
-                }
+            let height = geometry.size.height
+            let width = height * imageRatio
+            return CGSize(width: width, height: height)
         }
     }
     
     private func loadImage() {
         Task {
-            if fileName.lowercased().hasSuffix(".jpg") || fileName.lowercased().hasSuffix(".jpeg") || fileName.lowercased().hasSuffix(".png") {
+            if fileName.lowercased().hasSuffix(".jpg") ||
+                fileName.lowercased().hasSuffix(".jpeg") ||
+                fileName.lowercased().hasSuffix(".png") {
                 self.image = await ImageFileManager.shared.loadImage(fileName: fileName)
             } else {
                 self.image = UIImage(named: fileName)
@@ -87,15 +160,15 @@ struct ZoomableAsyncPhotoImageView: View {
 }
 
 #Preview("가로 꽉 채우기 (기본)") {
-    ZoomableAsyncPhotoImageView(fileName: "sample_image3", onScaleChanged: { CGFloat in
-        print("yeah!")
-    })
-        .frame(maxWidth: .infinity)
+    ZoomableAsyncPhotoImageView(fileName: "sample_image3") { scale in
+        print("Scale changed: \(scale)")
+    }
+    .frame(maxWidth: .infinity)
 }
 
 #Preview("전체 이미지 맞춤") {
-    ZoomableAsyncPhotoImageView(fileName: "sample_image2", onScaleChanged: { CGFloat in
-        print("yeah!")
-    })
-        .frame(height: 300)
+    ZoomableAsyncPhotoImageView(fileName: "sample_image2") { scale in
+        print("Scale changed: \(scale)")
+    }
+    .frame(height: 300)
 }

--- a/PawCut/PawCut/Sources/DesignSystem/Component/Image/ZoomableAsyncPhotoImageView.swift
+++ b/PawCut/PawCut/Sources/DesignSystem/Component/Image/ZoomableAsyncPhotoImageView.swift
@@ -35,9 +35,8 @@ struct ZoomableAsyncPhotoImageView: View {
                     .scaleEffect(currentScale)
                     .offset(limitedOffset(for: geometry, image: image))
                     .gesture(makeZoomAndPanGesture(for: geometry, image: image))
-                    .onTapGesture(count: 2) {
-                        handleDoubleTap()
-                    }
+                    .onTapGesture(count: 2) { currentScale == minScale ? handleDoubleTap() : () }
+
             } else {
                 Image("empty_image")
                     .frame(maxWidth: .infinity)

--- a/PawCut/PawCut/Sources/ViewModels/Archive/PhotoDetailsViewModel.swift
+++ b/PawCut/PawCut/Sources/ViewModels/Archive/PhotoDetailsViewModel.swift
@@ -239,14 +239,14 @@ private extension PhotoDetailsViewModel {
         }
     }
     
-    func willShowToastMessage(_ message: String) {
+    func showToastMessage(_ message: String) {
         toastMessage = message
         showToast = true
     }
     
     func handleResult(message: String, haptic: HapticType) async {
         await MainActor.run {
-            willShowToastMessage(message)
+            showToastMessage(message)
             triggerHaptic(haptic)
         }
     }

--- a/PawCut/PawCut/Sources/ViewModels/Archive/PhotoDetailsViewModel.swift
+++ b/PawCut/PawCut/Sources/ViewModels/Archive/PhotoDetailsViewModel.swift
@@ -12,9 +12,9 @@ import Photos
 @MainActor
 final class PhotoDetailsViewModel: ObservableObject {
     
-    @Published var groupedPhotos: [Date: [Photo]] = [:]
-    @Published var currentDate: Date = Date()
-    @Published var currentIndex: Int = 0
+    @Published private(set) var groupedPhotos: [Date: [Photo]] = [:]
+    @Published var currentDate: Date
+    @Published var currentIndex: Int
     @Published var showDeleteConfirmation: Bool = false
     @Published var showToast: Bool = false
     @Published var toastMessage: String = ""
@@ -28,7 +28,7 @@ final class PhotoDetailsViewModel: ObservableObject {
     }
     
     var currentPhotos: [Photo] {
-        return groupedPhotos[currentDate.startOfDay] ?? []
+        groupedPhotos[currentDate.startOfDay] ?? []
     }
     
     var currentPhoto: Photo? {
@@ -36,7 +36,7 @@ final class PhotoDetailsViewModel: ObservableObject {
         return currentPhotos[currentIndex]
     }
     
-    init(initialDate: Date = Date(), initialIndex: Int = 0) {
+    init(initialDate: Date, initialIndex: Int) {
         self.currentDate = initialDate.startOfDay
         self.currentIndex = initialIndex
     }
@@ -95,57 +95,58 @@ private extension PhotoDetailsViewModel {
             do {
                 let authStatus = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
                 let permissionStatus = PhotoPermissionStatus(from: authStatus)
-
+                
                 guard permissionStatus.canSavePhoto else {
-                    handleResult(message: permissionStatus.userMessage, haptic: .error)
+                    await handleResult(message: permissionStatus.userMessage, haptic: .error)
                     return
                 }
-
+                
                 guard let image = await imageFileManager.loadImage(fileName: photo.fileName) else {
-                    handleResult(message: "사진을 불러올 수 없어요.", haptic: .error)
+                    await handleResult(message: "사진을 불러올 수 없어요.", haptic: .error)
                     return
                 }
-
+                
                 try await imageFileManager.saveToPhotoLibrary(image: image)
-                handleResult(message: "저장이 완료되었어요.", haptic: .success)
+                await handleResult(message: "저장이 완료되었어요.", haptic: .success)
             } catch {
-                handleResult(message: "저장에 실패했어요.", haptic: .error)
+                await handleResult(message: "저장에 실패했어요.", haptic: .error)
             }
         }
     }
-
+    
     func deletePhoto(_ photo: Photo) {
         Task {
             await performDelete(photo)
         }
     }
-
+    
     private func performDelete(_ photo: Photo) async {
         guard let modelContext = modelContext else { return }
-
+        
         do {
             try await imageFileManager.deleteFile(fileName: photo.fileName)
             modelContext.delete(photo)
             try modelContext.save()
-
-            loadPhotosFromDatabase() // 갱신
-            handleResult(message: "사진이 삭제되었어요.", haptic: .success)
+            
+            loadPhotosFromDatabase()
+            await handleResult(message: "사진이 삭제되었어요.", haptic: .success)
         } catch {
-            handleResult(message: "사진을 삭제할 수 없어요.", haptic: .error)
+            await handleResult(message: "사진을 삭제할 수 없어요.", haptic: .error)
         }
     }
-
+    
+    // TODO: SwiftData 로직 구현 필요
     func loadPhotosFromDatabase() {
         guard let modelContext = modelContext else { return }
-
+        
         Task {
             do {
                 let descriptor = FetchDescriptor<Photo>(sortBy: [SortDescriptor(\.createdAt, order: .forward)])
                 let allPhotos = try modelContext.fetch(descriptor)
-
+                
                 let calendar = Calendar.current
                 var newGroupedPhotos: [Date: [Photo]] = [:]
-
+                
                 for photo in allPhotos {
                     let dayKey = calendar.startOfDay(for: photo.createdAt)
                     if newGroupedPhotos[dayKey] == nil {
@@ -153,35 +154,35 @@ private extension PhotoDetailsViewModel {
                     }
                     newGroupedPhotos[dayKey]?.append(photo)
                 }
-
+                
                 groupedPhotos = newGroupedPhotos
-                updateCurrentPhotosAndIndex()
-
+                willUpdateCurrentPhotosAndIndex()
+                
                 if groupedPhotos.isEmpty {
                     navigateBack()
                 }
             } catch {
-                handleResult(message: "사진 목록을 불러오지 못했어요.", haptic: .error)
+                await handleResult(message: "사진 목록을 불러오지 못했어요.", haptic: .error)
             }
         }
     }
-
-    func updateCurrentPhotosAndIndex() {
+    
+    func willUpdateCurrentPhotosAndIndex() {
         let normalizedCurrentDate = currentDate.startOfDay
-
+        
         if groupedPhotos[normalizedCurrentDate]?.isEmpty != false {
             if let latestDate = sortedDates.last {
                 currentDate = latestDate
                 currentIndex = 0
             }
         }
-
+        
         let photosCount = currentPhotos.count
         if currentIndex >= photosCount {
             currentIndex = max(0, photosCount - 1)
         }
     }
-
+    
     func getAllPhotos() -> [Photo] {
         sortedDates.flatMap { groupedPhotos[$0.startOfDay] ?? [] }
     }
@@ -190,31 +191,31 @@ private extension PhotoDetailsViewModel {
 private extension PhotoDetailsViewModel {
     func moveToNextImage() {
         let allPhotos = getAllPhotos()
-
+        
         if let currentPhoto = currentPhoto,
            let currentAllIndex = allPhotos.firstIndex(where: { $0.id == currentPhoto.id }),
            currentAllIndex < allPhotos.count - 1 {
             let nextPhoto = allPhotos[currentAllIndex + 1]
             let nextDate = nextPhoto.createdAt.startOfDay
             let nextIndexInDate = groupedPhotos[nextDate]?.firstIndex(where: { $0.id == nextPhoto.id }) ?? 0
-
+            
             currentDate = nextDate
             currentIndex = nextIndexInDate
             
             triggerHaptic(.selection)
         }
     }
-
+    
     func moveToPreviousImage() {
         let allPhotos = getAllPhotos()
-
+        
         if let currentPhoto = currentPhoto,
            let currentAllIndex = allPhotos.firstIndex(where: { $0.id == currentPhoto.id }),
            currentAllIndex > 0 {
             let previousPhoto = allPhotos[currentAllIndex - 1]
             let previousDate = previousPhoto.createdAt.startOfDay
             let previousIndexInDate = groupedPhotos[previousDate]?.firstIndex(where: { $0.id == previousPhoto.id }) ?? 0
-
+            
             currentDate = previousDate
             currentIndex = previousIndexInDate
             
@@ -223,30 +224,30 @@ private extension PhotoDetailsViewModel {
     }
 }
 
-extension PhotoDetailsViewModel {
+private extension PhotoDetailsViewModel {
     enum HapticType {
         case success
         case selection
         case error
-        case saveComplete
     }
-
+    
     func triggerHaptic(_ type: HapticType) {
         switch type {
         case .success: HapticManager.shared.triggerSuccess()
         case .selection: HapticManager.shared.triggerSelection()
         case .error: HapticManager.shared.triggerError()
-        case .saveComplete: HapticManager.shared.triggerSaveComplete()
         }
     }
-
-    func showToastMessage(_ message: String) {
+    
+    func willShowToastMessage(_ message: String) {
         toastMessage = message
         showToast = true
     }
-
-    func handleResult(message: String, haptic: HapticType) {
-        showToastMessage(message)
-        triggerHaptic(haptic)
+    
+    func handleResult(message: String, haptic: HapticType) async {
+        await MainActor.run {
+            willShowToastMessage(message)
+            triggerHaptic(haptic)
+        }
     }
 }

--- a/PawCut/PawCut/Sources/Views/Archive/SubViews/Details/PhotoDetailsImageGalleryView.swift
+++ b/PawCut/PawCut/Sources/Views/Archive/SubViews/Details/PhotoDetailsImageGalleryView.swift
@@ -31,7 +31,6 @@ struct PhotoDetailsImageGallery: View {
                     ZoomableAsyncPhotoImageView(fileName: photo.fileName) { newScale in
                         isZoomedIn = newScale > 1.0
                     }
-                    .aspectRatio(contentMode: .fit)
                     .sideTapNavigationGesture(
                         onTapLeft: {
                             if !isZoomedIn {


### PR DESCRIPTION
<!--
PR을 제출하기 전에 다음 사항들을 확인해주세요:
- 제목에 PR의 내용을 명확히 설명했나요?
- 모든 코드를 로컬 환경에서 테스트해 보았나요?
- 관련 문서를 업데이트했나요?
-->

## 변경 사항 (Changes)
<!--
이 PR에서 변경된 내용을 간략하게 설명해주세요.
-->

7899cad refactor: 코드 정리
85de413 refactor: SimultaneousGesture 를 이용한 통합 제스쳐 관리 (zoom, pan)
658ed9a fix: aspectRatio 중복 제거

## 변경 이유 (Reason for Changes)
<!--
이 변경 사항이 필요한 이유와 문제를 어떻게 해결하는지 설명해주세요.
-->

ZoomableAsyncPhotoImageView.swift 파일에서
Gesture 를 SimultaneousGesture 에 담아 두 개 이상의 제스처를 동시에 인식하도록 해주도록 리팩토링함.

```
    private func makeZoomAndPanGesture(for geometry: GeometryProxy, image: UIImage) -> some Gesture {
        SimultaneousGesture(
            magnificationGesture(),
            dragGesture(for: geometry, image: image)
        )
    }
```

디바이스 사이즈를 잰 뒤 양끝점 이상으로 pan gesture 가 적용되지 않도록 수정함.
```
    private func limitedOffset(for geometry: GeometryProxy, image: UIImage) -> CGSize {
        guard currentScale > 1.0 else {
            return .zero
        }
        
        let imageSize = calculateImageSize(for: geometry, image: image)
        let scaledWidth = imageSize.width * currentScale
        let scaledHeight = imageSize.height * currentScale
        
        let maxOffsetX = max(0, (scaledWidth - geometry.size.width) / 2)
        let maxOffsetY = max(0, (scaledHeight - geometry.size.height) / 2)
        
        let limitedX = min(max(currentOffset.width, -maxOffsetX), maxOffsetX)
        let limitedY = min(max(currentOffset.height, -maxOffsetY), maxOffsetY)
        
        return CGSize(width: limitedX, height: limitedY)
    }
```

## 관련 이슈 (Related Issue)
<!--
이 PR이 해결하는 관련 이슈 번호를 참조하세요. 예: #123
-->
closed #205 

## 테스트 방법 (How to Test)
<!--
변경 사항이 적용되었는지 테스트하기 위해 수행해야 하는 단계를 설명해주세요.
1. Go to '...'
2. Click on '...'
3. Observe '...'
-->

## 추가 정보 (Additional Information)
<!--
이 PR에 대한 추가적인 정보가 있으면 제공해주세요.
-->
