### PR TITLE
[Fix] 스플래시 화면에서 전환하는 방식 변경

### DIFF
--- a/PawCut/PawCut/Sources/Application/PawCutApp.swift
+++ b/PawCut/PawCut/Sources/Application/PawCutApp.swift
@@ -23,7 +23,6 @@ struct PawCutApp: App {
         WindowGroup {
             ZStack {
                 ContentView()
-                    .scaleEffect(showSplash ? 0.95 : 1.0)
                     .opacity(showSplash ? 0 : 1)
                 
                 if showSplash {


### PR DESCRIPTION
<!--
PR을 제출하기 전에 다음 사항들을 확인해주세요:
- 제목에 PR의 내용을 명확히 설명했나요?
- 모든 코드를 로컬 환경에서 테스트해 보았나요?
- 관련 문서를 업데이트했나요?
-->

## 변경 사항 (Changes)
<!--
이 PR에서 변경된 내용을 간략하게 설명해주세요.
-->
#210 

## 변경 이유 (Reason for Changes)
<!--
이 변경 사항이 필요한 이유와 문제를 어떻게 해결하는지 설명해주세요.
-->

SplashView -> 메인화면 전환 시 어색해보이는 부분 확인 후 수정

PawCutApp.swift


## 관련 이슈 (Related Issue)
<!--
이 PR이 해결하는 관련 이슈 번호를 참조하세요. 예: #123
-->
#210 

## 테스트 방법 (How to Test)
<!--
변경 사항이 적용되었는지 테스트하기 위해 수행해야 하는 단계를 설명해주세요.
1. Go to '...'
2. Click on '...'
3. Observe '...'
-->

## 추가 정보 (Additional Information)
<!--
이 PR에 대한 추가적인 정보가 있으면 제공해주세요.
-->

화면 전환 시 사이즈가 작아졌다가 커지는 효과가 있어서, 어색하게 보이는 점이 있었습니다.

opacity 0 -> 1 애니메이션은 그대로 두고, 사이즈가 작아졌다가 원 비율로 보이는 코드만 제거했습니다.